### PR TITLE
tooling: re-enabling validate-go-get now AADB2C exists

### DIFF
--- a/scripts/validate-go-get.sh
+++ b/scripts/validate-go-get.sh
@@ -6,7 +6,7 @@ mkdir -p ./tmp/go-get
 cd ./tmp/go-get
 echo 'package main
 
-//import _ "github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants"
+import _ "github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants"
 
 func main() {
 }


### PR DESCRIPTION
This was temporarily disabled until the AADB2C package it relies on exists, which was added in #1 