### PR TITLE
`sdk/client`: update `(*Response).Unmarshal` for `[]byte` type

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -218,14 +218,12 @@ func (r *Response) Unmarshal(model interface{}) error {
 
 		// copy the byte stream across
 		switch bs := model.(type) {
-		case []byte:
-			model = respBody
 		case *[]byte:
 			*bs = respBody
 		case **[]byte:
 			*bs = &respBody
 		default:
-			return fmt.Errorf("internal-error: `model` must be []byte but got %+v", model)
+			return fmt.Errorf("internal-error: `model` must be *[]byte or **[]byte but got %+v", model)
 		}
 	}
 

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -161,7 +161,8 @@ func (r *Response) Unmarshal(model interface{}) error {
 	isContentType := func(typ string) bool {
 		return strings.Contains(contentType, typ)
 	}
-	if isContentType("application/json") {
+	switch {
+	case isContentType("application/json"):
 		// Read the response body and close it
 		respBody, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -179,9 +180,7 @@ func (r *Response) Unmarshal(model interface{}) error {
 
 		// Reassign the response body as downstream code may expect it
 		r.Body = io.NopCloser(bytes.NewBuffer(respBody))
-	}
-
-	if isContentType("application/xml") || isContentType("text/xml") {
+	case isContentType("application/xml") || isContentType("text/xml"):
 		// Read the response body and close it
 		respBody, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -199,9 +198,7 @@ func (r *Response) Unmarshal(model interface{}) error {
 
 		// Reassign the response body as downstream code may expect it
 		r.Body = io.NopCloser(bytes.NewBuffer(respBody))
-	}
-
-	if isContentType("application/octet-stream") || strings.HasPrefix(contentType, "text/") {
+	case isContentType("application/octet-stream") || strings.HasPrefix(contentType, "text/"):
 		// Read the response body and close it
 		respBody, err := io.ReadAll(r.Body)
 		if err != nil {

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -201,8 +201,7 @@ func (r *Response) Unmarshal(model interface{}) error {
 		r.Body = io.NopCloser(bytes.NewBuffer(respBody))
 	}
 
-	if isContentType("application/octet-stream") ||
-		isContentType("text/powershell") {
+	if isContentType("application/octet-stream") || strings.HasPrefix(contentType, "text/") {
 		// Read the response body and close it
 		respBody, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -222,8 +221,13 @@ func (r *Response) Unmarshal(model interface{}) error {
 			*bs = respBody
 		case **[]byte:
 			*bs = &respBody
+		case *string:
+			*bs = string(respBody)
+		case **string:
+			str := string(respBody)
+			*bs = &str
 		default:
-			return fmt.Errorf("internal-error: `model` must be *[]byte or **[]byte but got %+v", model)
+			return fmt.Errorf("internal-error: `model` must be *[]byte, **[]byte, *string or **string, but got %+v", model)
 		}
 	}
 

--- a/sdk/client/client_test.go
+++ b/sdk/client/client_test.go
@@ -54,11 +54,16 @@ func TestAccClient(t *testing.T) {
 	// unmarshal as *[]byte
 	resp.Header.Set("Content-Type", "application/octet-stream")
 	var bs []byte
-	if err := resp.Unmarshal(&bs); err != nil {
+	// pass slice itself will not work
+	if err = resp.Unmarshal(bs); err == nil {
+		t.Fatalf("response []byte should raise an error")
+	}
+
+	if err = resp.Unmarshal(&bs); err != nil {
 		t.Fatal(err)
 	}
 	var bsPtr *[]byte
-	if err := resp.Unmarshal(&bsPtr); err != nil {
+	if err = resp.Unmarshal(&bsPtr); err != nil {
 		t.Fatal(err)
 	}
 

--- a/sdk/client/client_test.go
+++ b/sdk/client/client_test.go
@@ -39,8 +39,34 @@ func TestAccClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = req.ExecutePaged(ctx)
+	resp, err := req.ExecutePaged(ctx)
 	if err != nil {
 		t.Fatalf("ExecutePaged(): %v", err)
 	}
+
+	// test resp unmarshal as json
+	resp.Header.Set("Content-Type", "application/json")
+	var resJSON interface{}
+	if err = resp.Unmarshal(&resJSON); err != nil {
+		t.Fatal(err)
+	}
+
+	// unmarshal as *[]byte
+	resp.Header.Set("Content-Type", "application/octet-stream")
+	var bs []byte
+	if err := resp.Unmarshal(&bs); err != nil {
+		t.Fatal(err)
+	}
+	var bsPtr *[]byte
+	if err := resp.Unmarshal(&bsPtr); err != nil {
+		t.Fatal(err)
+	}
+
+	// unmarshal to XML should raise an error
+	resp.Header.Set("Content-Type", "text/xml")
+	var resXML interface{}
+	if err = resp.Unmarshal(&resXML); err == nil {
+		t.Fatal("should raise an error when unmarshalling to XML")
+	}
+
 }


### PR DESCRIPTION
And update the Test code for response.Unmarshal for different types.

This will workaround https://github.com/hashicorp/pandora/pull/1756 when working with the new Base layer.


```
=== RUN   TestAccClient
--- PASS: TestAccClient (1.36s)
PASS
```