### PR TITLE
Test fix and OData tweaks

### DIFF
--- a/sdk/client/options.go
+++ b/sdk/client/options.go
@@ -13,35 +13,71 @@ type Options interface {
 	ToQuery() *QueryParams
 }
 
+// Headers is a representation of the HTTP headers to be sent with a Request
 type Headers struct {
-	val map[string]string
+	vals map[string]string
 }
 
-func (h Headers) Append(key, value string) {
-	if h.val == nil {
-		h.val = map[string]string{}
+// AppendHeader appends the http.Header values
+func (h *Headers) AppendHeader(h2 http.Header) {
+	if h.vals == nil {
+		h.vals = map[string]string{}
 	}
-	h.val[key] = value
+	for k, v := range h2 {
+		if len(v) > 0 {
+			h.vals[k] = v[0]
+		}
+	}
 }
 
-func (h Headers) Headers() http.Header {
+// Append sets a single header value
+func (h *Headers) Append(key, value string) {
+	if h.vals == nil {
+		h.vals = map[string]string{}
+	}
+	h.vals[key] = value
+}
+
+// Merge copies the header values from h2, overwriting as necessary
+func (h *Headers) Merge(h2 Headers) {
+	if h.vals == nil {
+		h.vals = map[string]string{}
+	}
+	if h2.vals == nil {
+		return
+	}
+	for k, v := range h2.vals {
+		h.vals[k] = v
+	}
+}
+
+// Headers returns an http.Headers map containing header values
+func (h *Headers) Headers() http.Header {
 	out := make(http.Header)
-	for k, v := range h.val {
+	for k, v := range h.vals {
 		out.Add(k, v)
 	}
 	return out
 }
 
+// QueryParams is a representation of the URL query parameters to be sent with a Request
 type QueryParams struct {
 	vals map[string]string
 }
 
-func QueryParamsFromValues(input map[string]string) *QueryParams {
-	return &QueryParams{
-		vals: input,
+// AppendValues appends the url.Values values
+func (q *QueryParams) AppendValues(q2 url.Values) {
+	if q.vals == nil {
+		q.vals = map[string]string{}
+	}
+	for k, v := range q2 {
+		if len(v) > 0 {
+			q.vals[k] = v[0]
+		}
 	}
 }
 
+// Append sets a single query parameter value
 func (q *QueryParams) Append(key, value string) {
 	if q.vals == nil {
 		q.vals = map[string]string{}
@@ -49,6 +85,20 @@ func (q *QueryParams) Append(key, value string) {
 	q.vals[key] = value
 }
 
+// Merge copies the query parameter values from q2, overwriting as necessary
+func (q *QueryParams) Merge(q2 Headers) {
+	if q.vals == nil {
+		q.vals = map[string]string{}
+	}
+	if q2.vals == nil {
+		return
+	}
+	for k, v := range q2.vals {
+		q.vals[k] = v
+	}
+}
+
+// Values returns a url.Values map containing query parameter values
 func (q *QueryParams) Values() url.Values {
 	va := make(url.Values)
 	for k, v := range q.vals {

--- a/sdk/client/resourcemanager/poller_provisioning_state.go
+++ b/sdk/client/resourcemanager/poller_provisioning_state.go
@@ -176,7 +176,7 @@ func (p provisioningStateOptions) ToOData() *odata.Query {
 }
 
 func (p provisioningStateOptions) ToQuery() *client.QueryParams {
-	return client.QueryParamsFromValues(map[string]string{
-		"api-version": p.apiVersion,
-	})
+	q := client.QueryParams{}
+	q.Append("api-version", p.apiVersion)
+	return &q
 }

--- a/sdk/internal/metadata/client_test.go
+++ b/sdk/internal/metadata/client_test.go
@@ -1,4 +1,4 @@
-package metadata
+package metadata_test
 
 import (
 	"context"
@@ -8,6 +8,9 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/internal/metadata"
+	"github.com/hashicorp/go-azure-sdk/sdk/internal/test"
 )
 
 var (
@@ -18,6 +21,8 @@ var (
 )
 
 func TestGetMetaData(t *testing.T) {
+	test.AccTest(t)
+
 	ctx := context.Background()
 	port := 8000 + rand.Intn(999)
 	done := metadataStubServer(ctx, port)
@@ -25,13 +30,13 @@ func TestGetMetaData(t *testing.T) {
 		done <- true
 	}()
 
-	client := NewClientWithEndpoint(fmt.Sprintf("http://localhost:%d", port))
+	client := metadata.NewClientWithEndpoint(fmt.Sprintf("http://localhost:%d", port))
 	if client == nil {
 		t.Fatal("client was nil")
 	}
 
-	expected := MetaData{
-		Authentication: Authentication{
+	expected := metadata.MetaData{
+		Authentication: metadata.Authentication{
 			Audiences: []string{
 				"https://management.core.windows.net/",
 				"https://management.azure.com/",
@@ -40,7 +45,7 @@ func TestGetMetaData(t *testing.T) {
 			IdentityProvider: "AAD",
 			Tenant:           "common",
 		},
-		DnsSuffixes: DnsSuffixes{
+		DnsSuffixes: metadata.DnsSuffixes{
 			Attestation: "attest.azure.net",
 			FrontDoor:   "azurefd.net",
 			KeyVault:    "vault.azure.net",
@@ -54,7 +59,7 @@ func TestGetMetaData(t *testing.T) {
 			Synapse:     "dev.azuresynapse.net",
 		},
 		Name: "AzureCloud",
-		ResourceIdentifiers: ResourceIdentifiers{
+		ResourceIdentifiers: metadata.ResourceIdentifiers{
 			Attestation:    "https://attest.azure.net",
 			Batch:          "https://batch.core.windows.net",
 			LogAnalytics:   "https://api.loganalytics.io",

--- a/sdk/odata/query.go
+++ b/sdk/odata/query.go
@@ -60,13 +60,12 @@ type Query struct {
 	Top int
 }
 
-// Headers returns an http.Header map containing OData specific headers, for use in requests
+// Headers returns an http.Header map containing OData specific headers
 func (q Query) Headers() http.Header {
 	// Take extra care over canonicalization of header names
-	headers := http.Header{
-		"Odata-Maxversion": []string{ODataVersion},
-		"Odata-Version":    []string{ODataVersion},
-	}
+	headers := http.Header{}
+	headers.Set("Odata-Maxversion", ODataVersion)
+	headers.Set("Odata-Version", ODataVersion)
 
 	accept := "application/json; charset=utf-8; IEEE754Compatible=false"
 	if q.Metadata != "" {
@@ -94,9 +93,10 @@ func (q Query) AppendHeaders(header http.Header) http.Header {
 	return header
 }
 
-// Values returns a url.Values map containing OData specific query parameters, for use in requests
+// Values returns a url.Values map containing OData specific query parameters
 func (q Query) Values() url.Values {
 	p := url.Values{}
+
 	if q.Count {
 		p.Add("$count", fmt.Sprintf("%t", q.Count))
 	}
@@ -124,6 +124,7 @@ func (q Query) Values() url.Values {
 	if q.Top > 0 {
 		p.Add("$top", strconv.Itoa(q.Top))
 	}
+
 	return p
 }
 


### PR DESCRIPTION
- Metadata client tests to run only as needed, similar to auth tests
- Refactor OData and Client types for easier re-use