### PR TITLE
sdk/environments: obtaining the scope from the endpoint if a resourceIdentifier isn't present

### DIFF
--- a/sdk/environments/scopes.go
+++ b/sdk/environments/scopes.go
@@ -18,7 +18,13 @@ func Resource(endpoint Api) (*string, error) {
 func Scope(endpoint Api) (*string, error) {
 	e, ok := endpoint.ResourceIdentifier()
 	if !ok {
-		return nil, fmt.Errorf("the endpoint %q is not supported in this Azure Environment", endpoint.Name())
+		// if this API has been defined in-line it may not have a Resource Identifier - however
+		// the scope will be the endpoint instead, so we can best-effort to obtain the auth token
+		e2, ok2 := endpoint.Endpoint()
+		if !ok2 {
+			return nil, fmt.Errorf("the endpoint %q is not supported in this Azure Environment", endpoint.Name())
+		}
+		e = e2
 	}
 	out := fmt.Sprintf("%s/.default", *e)
 	return pointer.To(out), nil


### PR DESCRIPTION
This allows inlined Apis such as App Configuration Data Plane to obtain an auth token