### PR TITLE
Switch PKCS#12 library to software.sslmate.com/src/go-pkcs12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	golang.org/x/crypto v0.5.0
 	golang.org/x/oauth2 v0.4.0
+	software.sslmate.com/src/go-pkcs12 v0.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,7 @@ github.com/zclconf/go-cty v1.12.1 h1:PcupnljUm9EIvbgSHQnHhUr3fO6oFmkOrvs2BAFNXXY
 github.com/zclconf/go-cty v1.12.1/go.mod h1:s9IfD1LK5ccNMSWCVFCE2rJfHiZgi7JijgeWIMfhLvA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.5.0 h1:U/0M97KRkSFvyD/3FSmdP5W5swImpNgle/EHFhOsQPE=
 golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
@@ -156,3 +157,5 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+software.sslmate.com/src/go-pkcs12 v0.2.0 h1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
+software.sslmate.com/src/go-pkcs12 v0.2.0/go.mod h1:23rNcYsMabIc1otwLpTkCCPwUq6kQsTyowttG/as0kQ=

--- a/sdk/auth/client_certificate_authorizer.go
+++ b/sdk/auth/client_certificate_authorizer.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
-	"golang.org/x/crypto/pkcs12"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 type ClientCertificateAuthorizerOptions struct {
@@ -47,7 +47,8 @@ func NewClientCertificateAuthorizer(ctx context.Context, options ClientCertifica
 		}
 	}
 
-	key, cert, err := pkcs12.Decode(options.Pkcs12Data, options.Pkcs12Pass)
+	// we aren't interested in the issuer chain, but we use the DecodeChain method to parse them out in case they are present
+	key, cert, _, err := pkcs12.DecodeChain(options.Pkcs12Data, options.Pkcs12Pass)
 	if err != nil {
 		return nil, fmt.Errorf("could not decode PKCS#12 archive: %s", err)
 	}


### PR DESCRIPTION
golang.org/x/crypto/pkcs12 is unmaintained, this replacement is license compatible and more up-to-date.

This wins us the following:
- Support for parsing out certificate chains stored in PKCS#12 bundles
- Support for SHA256 HMAC which is the default hash function for PKCS#12 bundles with newer versions of OpenSSL/LibreSSL