### PR TITLE
tooling: updating the open pr script to run via bash

### DIFF
--- a/.github/workflows/automation-open-pull-request.yaml
+++ b/.github/workflows/automation-open-pull-request.yaml
@@ -13,9 +13,7 @@ jobs:
       - name: "open a pull request"
         id: open-pr
         run: |
-          # this runs everytime the PR gets pushed too, whilst you can only create a PR a single time
-          # so we should be smarter, but piping this to /dev/null is a fine workaround for MVP
-          gh pr create --title "$PR_TITLE" --body "$PR_BODY" -B "$PR_TARGET" -l "$PR_LABEL" > /dev/null
+          bash ./scripts/open-pull-request.sh "$PR_TITLE" "$PR_BODY" "$PR_TARGET" "$PR_LABEL"
 
         env:
           PR_TITLE: "Auto PR: Regenerating the Go SDK (${{ github.sha }})"

--- a/scripts/open-pull-request.sh
+++ b/scripts/open-pull-request.sh
@@ -1,0 +1,14 @@
+function main {
+  local prTitle="$1"
+  local prBody="$2"
+  local branch="$3"
+  local label="$4"
+
+  # this runs everytime the PR gets pushed too, whilst you can only create a PR a single time
+  # so we should be smarter, but just trying to trigger this should be sufficient for now
+  result=$(gh pr create --title "$prTitle" --body "$prBody" -B "$branch" -l "$label")
+  echo "$result"
+  exit 0
+}
+
+main "$1" "$2" "$3" "$4"


### PR DESCRIPTION
This PR updates the 'open-pull-request' job to launch a bash script with an explicit exit code, rather than erroring directly