### PR TITLE
dependencies: updating to `v0.53.0` of `github.com/hashicorp/go-azure-helpers`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.28
 	github.com/Azure/go-autorest/autorest/adal v0.9.22
 	github.com/davecgh/go-spew v1.1.1
-	github.com/hashicorp/go-azure-helpers v0.52.0
+	github.com/hashicorp/go-azure-helpers v0.53.0
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-azure-helpers v0.52.0 h1:2xIjsPpDbZf5dFLEdqOy5akfdnh8M/6mQtVWhkpM3hM=
-github.com/hashicorp/go-azure-helpers v0.52.0/go.mod h1:lsykLR4KjTUO7MiRmNWiTiX8QQtw3ILjyOvT0f5h3rw=
+github.com/hashicorp/go-azure-helpers v0.53.0 h1:eFH8Kh0ffM+WglnYQeUxgSyYENcmfHy98NBdF5sbz0Y=
+github.com/hashicorp/go-azure-helpers v0.53.0/go.mod h1:RQugkG8wEcNIjYmcBLHpuEI/u2mTJwO4r37rR/OKRpo=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 h1:1/D3zfFHttUKaCaGKZ/dR2roBXv0vKbSCnssIldfQdI=


### PR DESCRIPTION
Exposes the `KeyVault` and `KeyVaultKey` Common IDs