### PR TITLE
Bugfix: skip auxiliary tokens for CLI auth instead of erroring

### DIFF
--- a/sdk/auth/azure_cli_authorizer.go
+++ b/sdk/auth/azure_cli_authorizer.go
@@ -93,6 +93,11 @@ func (a *AzureCliAuthorizer) AuxiliaryTokens(_ context.Context, _ *http.Request)
 		return nil, fmt.Errorf("could not request token: conf is nil")
 	}
 
+	// Return early if no auxiliary tenants are configured
+	if len(a.conf.AuxiliaryTenantIDs) == 0 {
+		return []*oauth2.Token{}, nil
+	}
+
 	// Try to detect if we're running in Cloud Shell
 	if cloudShell := os.Getenv("AZUREPS_HOST_ENVIRONMENT"); strings.HasPrefix(cloudShell, "cloud-shell/") {
 		return nil, fmt.Errorf("auxiliary tokens not supported in Cloud Shell")

--- a/sdk/auth/shared_key_authorizer.go
+++ b/sdk/auth/shared_key_authorizer.go
@@ -57,7 +57,8 @@ func (s *SharedKeyAuthorizer) Token(ctx context.Context, req *http.Request) (*oa
 }
 
 func (s *SharedKeyAuthorizer) AuxiliaryTokens(_ context.Context, _ *http.Request) ([]*oauth2.Token, error) {
-	return nil, fmt.Errorf("auxiliary tokens are not supported with SharedKey authentication")
+	// Auxiliary tokens are not supported with SharedKey authentication
+	return []*oauth2.Token{}, nil
 }
 
 // ---

--- a/sdk/auth/shared_key_authorizer.go
+++ b/sdk/auth/shared_key_authorizer.go
@@ -158,7 +158,7 @@ func buildCanonicalizedResource(accountName, uri string, keyType SharedKeyType) 
 		}
 	}
 
-	return string(cr.Bytes()), nil
+	return cr.String(), nil
 }
 
 func getCanonicalizedAccountName(accountName string) string {
@@ -243,7 +243,7 @@ func buildCanonicalizedHeader(headers http.Header) string {
 		ch.WriteRune('\n')
 	}
 
-	return strings.TrimSuffix(string(ch.Bytes()), "\n")
+	return strings.TrimSuffix(ch.String(), "\n")
 }
 
 func createAuthorizationHeader(accountName string, accountKey []byte, canonicalizedString string) string {


### PR DESCRIPTION
Related: https://github.com/hashicorp/terraform-provider-azurerm/issues/20674

Fixes a bug when authenticating via Azure CLI in Cloud Shell.

**Testing**

<img width="1281" alt="Screenshot 2023-03-07 at 13 23 27" src="https://user-images.githubusercontent.com/251987/223409319-a1ece73b-5f26-43a8-8fd6-e7f67324edb1.png">
