### PR TITLE
auth: use a retryable http client to handle 429 responses from token endpoint(s)

### DIFF
--- a/sdk/auth/client.go
+++ b/sdk/auth/client.go
@@ -1,0 +1,14 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// httpClient returns a shimmed retryablehttp Client, at the moment with default retry,
+// backoff and timeout settings, but we may need to change this in the future.
+func httpClient() *http.Client {
+	retryableClient := retryablehttp.NewClient()
+	return retryableClient.StandardClient()
+}

--- a/sdk/auth/client.go
+++ b/sdk/auth/client.go
@@ -1,14 +1,94 @@
 package auth
 
 import (
+	"context"
+	"math"
+	"net"
 	"net/http"
+	"net/url"
+	"runtime"
+	"strconv"
+	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-// httpClient returns a shimmed retryablehttp Client, at the moment with default retry,
-// backoff and timeout settings, but we may need to change this in the future.
-func httpClient() *http.Client {
-	retryableClient := retryablehttp.NewClient()
-	return retryableClient.StandardClient()
+type httpClientParams struct {
+	retryWaitMin  time.Duration
+	retryWaitMax  time.Duration
+	retryMaxCount int
+	timeout       time.Duration
+	useProxy      bool
+}
+
+func defaultHttpClientParams() httpClientParams {
+	return httpClientParams{
+		retryWaitMin:  1 * time.Second,
+		retryWaitMax:  30 * time.Second,
+		retryMaxCount: 8,
+		timeout:       10 * time.Second,
+		useProxy:      true,
+	}
+}
+
+// httpClient returns a shimmed retryablehttp Client, with custom backoff and
+// retry settings which can be customized per instance as needed.
+func httpClient(params httpClientParams) *http.Client {
+	r := retryablehttp.NewClient()
+
+	r.Backoff = func(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+		// note: min and max contain the values of r.RetryWaitMin and r.RetryWaitMax
+
+		if resp != nil {
+			// IMDS uses inappropriate 410 status to indicate a rebooting-like state, retry after 70 seconds
+			// See https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#retry-guidance
+			if resp.StatusCode == http.StatusGone {
+				return 70 * time.Second
+			}
+
+			// Always look for Retry-After header, regardless of HTTP status
+			if s, ok := resp.Header["Retry-After"]; ok {
+				if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
+					return time.Second * time.Duration(sleep)
+				}
+			}
+		}
+
+		// Exponential backoff when Retry-After header not provided, e.g. IMDS
+		mult := math.Pow(2, float64(attemptNum)) * float64(min)
+		sleep := time.Duration(mult)
+		if float64(sleep) != mult || sleep > max {
+			sleep = max
+		}
+		return sleep
+	}
+
+	var proxyFunc func(*http.Request) (*url.URL, error)
+	if params.useProxy {
+		proxyFunc = http.ProxyFromEnvironment
+	}
+
+	r.RetryWaitMin = params.retryWaitMin
+	r.RetryWaitMax = params.retryWaitMax
+
+	r.HTTPClient = &http.Client{
+		Transport: &http.Transport{
+			Proxy: proxyFunc,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				d := &net.Dialer{Resolver: &net.Resolver{}}
+				return d.DialContext(ctx, network, addr)
+			},
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
+		},
+	}
+
+	client := r.StandardClient()
+	client.Timeout = params.timeout
+
+	return client
 }

--- a/sdk/auth/client_credentials.go
+++ b/sdk/auth/client_credentials.go
@@ -310,7 +310,8 @@ func clientCredentialsToken(ctx context.Context, endpoint string, params *url.Va
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	client := httpClient()
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("clientCredentialsToken: cannot request token: %v", err)
 	}

--- a/sdk/auth/client_credentials.go
+++ b/sdk/auth/client_credentials.go
@@ -310,7 +310,7 @@ func clientCredentialsToken(ctx context.Context, endpoint string, params *url.Va
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	client := httpClient()
+	client := httpClient(defaultHttpClientParams())
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("clientCredentialsToken: cannot request token: %v", err)

--- a/sdk/auth/github_oidc_authorizer.go
+++ b/sdk/auth/github_oidc_authorizer.go
@@ -90,7 +90,7 @@ func (a *GitHubOIDCAuthorizer) githubAssertion(ctx context.Context, _ *http.Requ
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", a.conf.IDTokenRequestToken))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	client := httpClient()
+	client := httpClient(defaultHttpClientParams())
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("githubAssertion: cannot request token: %v", err)

--- a/sdk/auth/github_oidc_authorizer.go
+++ b/sdk/auth/github_oidc_authorizer.go
@@ -90,7 +90,8 @@ func (a *GitHubOIDCAuthorizer) githubAssertion(ctx context.Context, _ *http.Requ
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", a.conf.IDTokenRequestToken))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	client := httpClient()
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("githubAssertion: cannot request token: %v", err)
 	}

--- a/sdk/auth/managed_identity_authorizer.go
+++ b/sdk/auth/managed_identity_authorizer.go
@@ -170,6 +170,8 @@ func azureMetadata(ctx context.Context, url string) (body []byte, err error) {
 	}
 
 	client := httpClient(httpClientParams{
+		instanceMetadataService: true,
+
 		retryWaitMin:  2 * time.Second,
 		retryWaitMax:  60 * time.Second,
 		retryMaxCount: 5,

--- a/sdk/auth/managed_identity_authorizer.go
+++ b/sdk/auth/managed_identity_authorizer.go
@@ -169,10 +169,10 @@ func azureMetadata(ctx context.Context, url string) (body []byte, err error) {
 	req.Header = http.Header{
 		"Metadata": []string{"true"},
 	}
-	client := &http.Client{
-		Transport: http.DefaultTransport,
-		Timeout:   msiDefaultTimeout,
-	}
+
+	client := httpClient()
+	client.Timeout = msiDefaultTimeout
+
 	var resp *http.Response
 	log.Printf("[DEBUG] Performing %s Request to %q", req.Method, url)
 	resp, err = client.Do(req)

--- a/sdk/auth/managed_identity_authorizer.go
+++ b/sdk/auth/managed_identity_authorizer.go
@@ -170,8 +170,13 @@ func azureMetadata(ctx context.Context, url string) (body []byte, err error) {
 		"Metadata": []string{"true"},
 	}
 
-	client := httpClient()
-	client.Timeout = msiDefaultTimeout
+	client := httpClient(httpClientParams{
+		retryWaitMin:  2 * time.Second,
+		retryWaitMax:  60 * time.Second,
+		retryMaxCount: 5,
+		timeout:       msiDefaultTimeout,
+		useProxy:      false,
+	})
 
 	var resp *http.Response
 	log.Printf("[DEBUG] Performing %s Request to %q", req.Method, url)

--- a/sdk/auth/managed_identity_authorizer.go
+++ b/sdk/auth/managed_identity_authorizer.go
@@ -46,7 +46,6 @@ func NewManagedIdentityAuthorizer(ctx context.Context, options ManagedIdentityAu
 const (
 	msiDefaultApiVersion = "2018-02-01"
 	msiDefaultEndpoint   = "http://169.254.169.254/metadata/identity/oauth2/token"
-	msiDefaultTimeout    = 10 * time.Second
 )
 
 var _ Authorizer = &ManagedIdentityAuthorizer{}
@@ -174,7 +173,7 @@ func azureMetadata(ctx context.Context, url string) (body []byte, err error) {
 		retryWaitMin:  2 * time.Second,
 		retryWaitMax:  60 * time.Second,
 		retryMaxCount: 5,
-		timeout:       msiDefaultTimeout,
+		timeout:       10 * time.Second,
 		useProxy:      false,
 	})
 


### PR DESCRIPTION
Docs: https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/resilience-client-app
Related: https://github.com/hashicorp/terraform-provider-azurerm/issues/20901