### PR TITLE
sdk/environments: obtaining the resource from the endpoint if a resourceIdentifier isn't present

### DIFF
--- a/sdk/environments/scopes.go
+++ b/sdk/environments/scopes.go
@@ -9,7 +9,13 @@ import (
 func Resource(endpoint Api) (*string, error) {
 	resource, ok := endpoint.ResourceIdentifier()
 	if !ok {
-		return nil, fmt.Errorf("the endpoint %q doesn't define a resource identifier", endpoint.Name())
+		// if this API has been defined in-line it may not have a Resource Identifier - however
+		// the resource will be the endpoint instead, so we can best-effort to obtain the auth token
+		resource2, ok2 := endpoint.Endpoint()
+		if !ok2 {
+			return nil, fmt.Errorf("the endpoint %q is not supported in this Azure Environment", endpoint.Name())
+		}
+		resource = resource2
 	}
 
 	return resource, nil


### PR DESCRIPTION
Allow inlined Apis such as App Configuration Data Plane to obtain an auth token with MSI auth

related with https://github.com/hashicorp/terraform-provider-azurerm/issues/20835 and https://github.com/hashicorp/go-azure-sdk/pull/320

test:
```hcl
adminuser@example-machine:~/test$ cat main.tf
terraform {
  required_providers {
    azurerm = {
      source = "hashicorp/azurerm"
    }
  }
}
provider "azurerm" {
  features {}
  tenant_id       = "xxx"
  subscription_id = "xxx"
  use_msi         = true
}
resource "azurerm_resource_group" "example" {
  name     = "appconf-example-resources"
  location = "West Europe"
}
resource "azurerm_app_configuration" "appconf" {
  name                = "wttestappConf1"
  resource_group_name = azurerm_resource_group.example.name
  location            = azurerm_resource_group.example.location
}
resource "azurerm_app_configuration_key" "test" {
  configuration_store_id = azurerm_app_configuration.appconf.id
  key                    = "appConfKey1"
  label                  = "somelabel"
  value                  = "a test"
}


adminuser@example-machine:~/test$ terraform apply -auto-approve
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/azurerm in /home/adminuser/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_app_configuration.appconf will be created
  + resource "azurerm_app_configuration" "appconf" {
      + endpoint                   = (known after apply)
      + id                         = (known after apply)
      + local_auth_enabled         = true
      + location                   = "westeurope"
      + name                       = "wttestappConf1"
      + primary_read_key           = (known after apply)
      + primary_write_key          = (known after apply)
      + purge_protection_enabled   = false
      + resource_group_name        = "appconf-example-resources"
      + secondary_read_key         = (known after apply)
      + secondary_write_key        = (known after apply)
      + sku                        = "free"
      + soft_delete_retention_days = 7
    }

  # azurerm_app_configuration_key.test will be created
  + resource "azurerm_app_configuration_key" "test" {
      + configuration_store_id = (known after apply)
      + content_type           = (known after apply)
      + etag                   = (known after apply)
      + id                     = (known after apply)
      + key                    = "appConfKey1"
      + label                  = "somelabel"
      + locked                 = false
      + type                   = "kv"
      + value                  = "a test"
    }

  # azurerm_resource_group.example will be created
  + resource "azurerm_resource_group" "example" {
      + id       = (known after apply)
      + location = "westeurope"
      + name     = "appconf-example-resources"
    }

Plan: 3 to add, 0 to change, 0 to destroy.
azurerm_resource_group.example: Creating...
azurerm_resource_group.example: Creation complete after 0s [id=/subscriptions/xxx/resourceGroups/appconf-example-resources]
azurerm_app_configuration.appconf: Creating...
azurerm_app_configuration.appconf: Still creating... [10s elapsed]
azurerm_app_configuration.appconf: Creation complete after 11s [id=/subscriptions/xxx/resourceGroups/appconf-example-resources/providers/Microsoft.AppConfiguration/configurationStores/wttestappConf1]
azurerm_app_configuration_key.test: Creating...
azurerm_app_configuration_key.test: Creation complete after 1s [id=/subscriptions/xxx/resourceGroups/appconf-example-resources/providers/Microsoft.AppConfiguration/configurationStores/wttestappConf1/AppConfigurationKey/ap
pConfKey1/Label/somelabel]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```