### PR TITLE
`enviroments`: add `Attestation` api endpoint

### DIFF
--- a/sdk/environments/azure_public.go
+++ b/sdk/environments/azure_public.go
@@ -21,6 +21,7 @@ func AzurePublic() *Environment {
 	env.MicrosoftGraph = MicrosoftGraphAPI("https://graph.microsoft.com")
 
 	env.ApiManagement = ApiManagementAPI("azure-api.net")
+	env.Attestation = AttestationAPI("https://attest.azure.net")
 	env.Batch = BatchAPI("https://batch.core.windows.net")
 	env.CDNFrontDoor = CDNFrontDoorAPI("azurefd.net")
 	env.ContainerRegistry = ContainerRegistryAPI("azurecr.io")

--- a/sdk/environments/helpers.go
+++ b/sdk/environments/helpers.go
@@ -25,6 +25,16 @@ func ApiManagementAPI(domainSuffix string) Api {
 	}
 }
 
+func AttestationAPI(endpoint string) Api {
+	return &ApiEndpoint{
+		domainSuffix:       nil,
+		endpoint:           pointer.To(endpoint),
+		appId:              pointer.To(attestationServiceAppId),
+		name:               "AttestationService",
+		resourceIdentifier: nil,
+	}
+}
+
 func BatchAPI(endpoint string) *ApiEndpoint {
 	return &ApiEndpoint{
 		domainSuffix:       nil,


### PR DESCRIPTION
needed by Data plan SDK of Attestation(only support in "East US 2", "West Central US" & "UK South" ).