### PR TITLE
auth: remove client timeout and rely on the request context

### DIFF
--- a/sdk/auth/client.go
+++ b/sdk/auth/client.go
@@ -22,7 +22,6 @@ type httpClientParams struct {
 	retryWaitMin  time.Duration
 	retryWaitMax  time.Duration
 	retryMaxCount int
-	timeout       time.Duration
 	useProxy      bool
 }
 
@@ -33,7 +32,6 @@ func defaultHttpClientParams() httpClientParams {
 		retryWaitMin:  1 * time.Second,
 		retryWaitMax:  30 * time.Second,
 		retryMaxCount: 8,
-		timeout:       10 * time.Second,
 		useProxy:      true,
 	}
 }
@@ -96,8 +94,5 @@ func httpClient(params httpClientParams) *http.Client {
 		},
 	}
 
-	client := r.StandardClient()
-	client.Timeout = params.timeout
-
-	return client
+	return r.StandardClient()
 }

--- a/sdk/auth/managed_identity_authorizer.go
+++ b/sdk/auth/managed_identity_authorizer.go
@@ -157,11 +157,8 @@ func (c *managedIdentityConfig) TokenSource(_ context.Context) (Authorizer, erro
 }
 
 func azureMetadata(ctx context.Context, url string) (body []byte, err error) {
-	ctx2, cancel := context.WithDeadline(ctx, time.Now().Add(time.Second*30))
-	defer cancel()
-
 	var req *http.Request
-	req, err = http.NewRequestWithContext(ctx2, http.MethodGet, url, http.NoBody)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return
 	}
@@ -175,7 +172,6 @@ func azureMetadata(ctx context.Context, url string) (body []byte, err error) {
 		retryWaitMin:  2 * time.Second,
 		retryWaitMax:  60 * time.Second,
 		retryMaxCount: 5,
-		timeout:       10 * time.Second,
 		useProxy:      false,
 	})
 


### PR DESCRIPTION
The `http.Client{}.Timeout` field applies to all retried requests, since they all occur during the course of a single client request.

Per `net/http`, when the `Timeout` field is zero, it will have no effect and the request context has precedent:

```go
// Timeout specifies a time limit for requests made by this
// Client. The timeout includes connection time, any
// redirects, and reading the response body. The timer remains
// running after Get, Head, Post, or Do return and will
// interrupt reading of the Response.Body.
//
// A Timeout of zero means no timeout.
//
// The Client cancels requests to the underlying Transport
// as if the Request's Context ended.
//
// For compatibility, the Client will also use the deprecated
// CancelRequest method on Transport if found. New
// RoundTripper implementations should use the Request's Context
// for cancellation instead of implementing CancelRequest.
```

Replaces: #371 