### PR TITLE
Set  as the auth client's logger

### DIFF
--- a/sdk/auth/client.go
+++ b/sdk/auth/client.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"context"
+	"log"
 	"math"
 	"net"
 	"net/http"
@@ -40,6 +41,8 @@ func defaultHttpClientParams() httpClientParams {
 // retry settings which can be customized per instance as needed.
 func httpClient(params httpClientParams) *http.Client {
 	r := retryablehttp.NewClient()
+
+	r.Logger = log.Default()
 
 	r.Backoff = func(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
 		// note: min and max contain the values of r.RetryWaitMin and r.RetryWaitMax


### PR DESCRIPTION
This is to make the log from the client comply with the other provider logs (e.g. eliminating it from showing in the stderr during acctest, stream it to the provider log file path, etc.)