### PR TITLE
Bugfix: OData parsing for bad responses

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -400,9 +400,6 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 	if err != nil {
 		return resp, err
 	}
-	if resp == nil {
-		return resp, fmt.Errorf("nil response received")
-	}
 
 	// Determine whether response status is valid
 	if !containsStatusCode(req.ValidStatusCodes, resp.StatusCode) {

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -394,14 +394,14 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 		}
 	}
 
-	// Extract OData from response
-	resp.OData, err = odata.FromResponse(resp.Response)
-	if err != nil {
-		return resp, err
-	}
+	// Extract OData from response, intentionally ignoring any errors as it's not crucial to extract
+	// valid OData at this point (valid json can still error here, such as any non-object literal)
+	resp.OData, _ = odata.FromResponse(resp.Response)
 
 	// Determine whether response status is valid
 	if !containsStatusCode(req.ValidStatusCodes, resp.StatusCode) {
+		// The status code didn't match, but we also need to check the ValidStatusFUnc, if provided
+		// Note that the odata argument here is a best-effort and may be nil
 		if f := req.ValidStatusFunc; f != nil && f(resp.Response, resp.OData) {
 			return resp, nil
 		}

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -395,7 +395,6 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 	}
 
 	// Extract OData from response
-	var o *odata.OData
 	resp.OData, err = odata.FromResponse(resp.Response)
 	if err != nil {
 		return resp, err
@@ -403,15 +402,15 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 
 	// Determine whether response status is valid
 	if !containsStatusCode(req.ValidStatusCodes, resp.StatusCode) {
-		if f := req.ValidStatusFunc; f != nil && f(resp.Response, o) {
+		if f := req.ValidStatusFunc; f != nil && f(resp.Response, resp.OData) {
 			return resp, nil
 		}
 
 		// Determine suitable error text
 		var errText string
 		switch {
-		case o != nil && o.Error != nil && o.Error.String() != "":
-			errText = fmt.Sprintf("error: %s", o.Error)
+		case resp.OData != nil && resp.OData.Error != nil && resp.OData.Error.String() != "":
+			errText = fmt.Sprintf("error: %s", resp.OData.Error)
 
 		default:
 			defer resp.Body.Close()


### PR DESCRIPTION
Intentionally ignore errors when parsing OData for unpaged responses - this can fail for various reasons but notably when the JSON response is technically valid but comprises a non-object literal such as a string or int.

We are only parsing OData from the response here in order to pass it along to a provided ValidStatusFunc, and this is a best-effort as the provided *odata.OData may be nil.

Fixes: #381