### PR TITLE
auth: fix bad error check

### DIFF
--- a/sdk/auth/autorest/auth.go
+++ b/sdk/auth/autorest/auth.go
@@ -73,29 +73,25 @@ func (c *Authorizer) BearerAuthorizerCallback() *autorest.BearerAuthorizerCallba
 			return nil, fmt.Errorf("obtaining token: %v", err)
 		}
 
-		return autorest.NewBearerAuthorizer(&servicePrincipalTokenWrapper{
+		return autorest.NewBearerAuthorizer(&adalTokenProvider{
 			tokenType:  "Bearer",
 			tokenValue: token.AccessToken,
 		}), nil
 	})
 }
 
-type servicePrincipalTokenWrapper struct {
+type adalTokenProvider struct {
 	tokenType  string
 	tokenValue string
 }
 
-func (s *servicePrincipalTokenWrapper) OAuthToken() string {
+func (s *adalTokenProvider) OAuthToken() string {
 	return s.tokenValue
 }
 
-func (s *servicePrincipalTokenWrapper) Token() adal.Token {
+func (s *adalTokenProvider) Token() adal.Token {
 	return adal.Token{
 		AccessToken: s.tokenValue,
 		Type:        s.tokenType,
 	}
-}
-
-type ServicePrincipalToken interface {
-	Token() adal.Token
 }

--- a/sdk/auth/token.go
+++ b/sdk/auth/token.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/sdk/claims"
 )
 
-const tokenExpiryDelta = 10 * time.Minute
+const tokenExpiryDelta = 20 * time.Minute
 
 // tokenExpiresSoon returns true if the token expires within 10 minutes, or if more than 50% of its validity period has elapsed (if this can be determined), whichever is later
 func tokenDueForRenewal(token *oauth2.Token) bool {

--- a/sdk/auth/token.go
+++ b/sdk/auth/token.go
@@ -29,7 +29,7 @@ func tokenDueForRenewal(token *oauth2.Token) bool {
 	expiresWithinTenMinutes := expiry.Add(-delta).Before(now)
 
 	// Try to parse the token claims to retrieve the issuedAt time
-	if claims, err := claims.ParseClaims(token); err != nil {
+	if claims, err := claims.ParseClaims(token); err == nil {
 		if claims.IssuedAt > 0 {
 			issued := time.Unix(claims.IssuedAt, 0)
 			validity := expiry.Sub(issued)


### PR DESCRIPTION
also extend token renewal buffer to 20 minutes, so tokens are renewed 20 mins before their expiry (or after 50% of their validity period, whichever is earlier)

e.g.

Token Validity  | Renewed after
--- | ---
60 mins | 40 mins
50 mins | 35 mins
40 mins | 20 mins
30 mins | 15 mins
20 mins | 10 mins
10 mins | 5 mins