### PR TITLE
base-layer: add `Creating` as a valid status for LRO Poller

### DIFF
--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -160,6 +160,8 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			"Accepted": pollers.PollingStatusInProgress,
 			// CostManagement@2021-10-01 returns `Completed` rather than `Succeeded`: https://github.com/Azure/azure-sdk-for-go/issues/20342
 			"Completed": pollers.PollingStatusSucceeded,
+			// ContainerRegistry@2019-06-01-preview returns `Creating` rather than `InProgress` during creation
+			"Creating": pollers.PollingStatusInProgress,
 			// SignalR@2022-02-01 returns `Running` rather than `InProgress` during creation
 			"Running": pollers.PollingStatusInProgress,
 		}


### PR DESCRIPTION
`ContainerRegistry` `2019-06-01-preview` API for AgentPool returns `Creating` instead of `InProgress`