### PR TITLE
Enable logger for the request retryable client - same as `auth.Client`

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -10,6 +10,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"log"
 	"math"
 	"net"
 	"net/http"
@@ -535,7 +536,7 @@ func (c *Client) retryableClient(checkRetry retryablehttp.CheckRetry) (r *retrya
 
 	r.CheckRetry = checkRetry
 	r.ErrorHandler = RetryableErrorHandler
-	r.Logger = nil
+	r.Logger = log.Default()
 
 	r.HTTPClient = &http.Client{
 		Transport: &http.Transport{


### PR DESCRIPTION
Same as #382, but for the retryable client initialized during executing a `Request`. This and the `auth.Client` are the only two places that initialize the retryable client, hence needing this logger setting.