### PR TITLE
Remove the `ErrorHandler` for the per-request retryable client

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -67,10 +67,9 @@ func RequestRetryAll(retryFuncs ...RequestRetryFunc) func(resp *http.Response, o
 	}
 }
 
-// RetryableErrorHandler ensures that the response is returned after exhausting retries for a request
-// We mustn't return an error here, or net/http will not return the response
-func RetryableErrorHandler(resp *http.Response, _ error, _ int) (*http.Response, error) {
-	return resp, nil
+// RetryableErrorHandler simply returns the resp and err, this is needed to makes the retryablehttp client's Do() return early with the response body not drained.
+func RetryableErrorHandler(resp *http.Response, err error, _ int) (*http.Response, error) {
+	return resp, err
 }
 
 // Request embeds *http.Request and adds useful metadata


### PR DESCRIPTION
I'm not sure in which case we will make use of the response on a "failed" request. This seems to be an anti-pattern in Go, in which case users should assume the returned `value` is useless/undefined on a non-nil `error`. The only scenario is for error messaging, if that is the case, we can somehow wrap the response message to the `err` itself and return the `err` instead.

The motivation for this PR is that in a specific case that the DNS failed to resolve for the URL, the dail failed error message won't be returned, instead the client returns somethings like following:

```
2023/04/19 14:53:43 executing request: Get "https://mgdpestorageaccountnameg.blob.core.windows.net/": http: RoundTripper implementation (*retryablehttp.RoundTripper) returned a nil *Response with a nil error
exit status 1
```

This makes the error message useless. See https://github.com/hashicorp/terraform-provider-azurerm/pull/21464#issuecomment-1514238197 for the full context.