### PR TITLE
Ensure POST with not req body also defined the header `Content-Length`

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -316,6 +316,12 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 
 	var err error
 
+	// Ensure the Content-Lenght header is set for methods that define a meaning for enclosed content, i.e. POST and PUT.
+	// https://www.rfc-editor.org/rfc/rfc9110#section-8.6-5
+	if req.Method == "POST" || req.Method == "PUT" {
+		req.Header.Set("Content-Length", fmt.Sprintf("%d", req.ContentLength))
+	}
+
 	// Check we can read the request body and set a default empty body
 	var reqBody []byte
 	if req.Body != nil {
@@ -324,7 +330,6 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 			return nil, fmt.Errorf("reading request body: %v", err)
 		}
 		req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
-		req.Header.Set("Content-Length", fmt.Sprintf("%d", req.ContentLength))
 	}
 
 	// Instantiate a RetryableHttp client and configure its CheckRetry func


### PR DESCRIPTION
Ensure POST with not req body also defined the header `Content-Length`. The motivation of this PR is because I've encountered error from Azure service complaining the POST request has not defined the `Content-Lenght` in header:

```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
<HTML><HEAD><TITLE>Length Required</TITLE>
<META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
<BODY><h2>Length Required</h2>
<hr><p>HTTP Error 411. The request must be chunked or have a content length.</p>
</BODY></HTML>
```

See: https://github.com/hashicorp/terraform-provider-azurerm/pull/21481 for details.