### PR TITLE
client/sdk: support for `[]byte` requests and responses

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -105,14 +106,15 @@ func (r *Request) Marshal(payload interface{}) error {
 		return nil
 	}
 
-	if strings.Contains(contentType, "application/octet-stream") {
-		v, ok := payload.([]byte)
+	if strings.Contains(contentType, "application/octet-stream") || strings.Contains(contentType, "text/powershell") {
+		v, ok := payload.(*[]byte)
 		if !ok {
-			return fmt.Errorf("internal-error: `payload` must be []byte but got %+v", payload)
+			return fmt.Errorf("internal-error: `payload` must be *[]byte but got %+v", payload)
 		}
 
-		r.ContentLength = int64(len(v))
-		r.Body = io.NopCloser(bytes.NewReader(v))
+		r.ContentLength = int64(len(*v))
+		r.Body = io.NopCloser(bytes.NewReader(*v))
+		return nil
 	}
 
 	return fmt.Errorf("internal-error: unimplemented marshal function for content type %q", contentType)
@@ -179,6 +181,7 @@ func (r *Response) Unmarshal(model interface{}) error {
 
 		// Reassign the response body as downstream code may expect it
 		r.Body = io.NopCloser(bytes.NewBuffer(respBody))
+		return nil
 	}
 
 	if strings.Contains(contentType, "application/xml") || strings.Contains(contentType, "text/xml") {
@@ -199,11 +202,16 @@ func (r *Response) Unmarshal(model interface{}) error {
 
 		// Reassign the response body as downstream code may expect it
 		r.Body = io.NopCloser(bytes.NewBuffer(respBody))
+		return nil
 	}
 
-	if strings.Contains(contentType, "application/octet-stream") {
-		if _, ok := model.([]byte); !ok {
-			return fmt.Errorf("internal-error: `model` must be []byte but got %+v", model)
+	if strings.Contains(contentType, "application/octet-stream") || strings.Contains(contentType, "text/powershell") {
+		val := reflect.ValueOf(model)
+		if val.Kind() != reflect.Pointer {
+			return fmt.Errorf("internal-error: `model` must be a pointer but it wasn't")
+		}
+		if _, ok := model.(*[]byte); !ok {
+			return fmt.Errorf("internal-error: `model` must be *[]byte but got %+v", model)
 		}
 
 		// Read the response body and close it
@@ -217,13 +225,14 @@ func (r *Response) Unmarshal(model interface{}) error {
 		respBody = bytes.TrimPrefix(respBody, []byte("\xef\xbb\xbf"))
 
 		// copy the byte stream across
-		model = respBody
+		reflect.Indirect(reflect.ValueOf(model)).SetBytes(respBody)
 
 		// Reassign the response body as downstream code may expect it
 		r.Body = io.NopCloser(bytes.NewBuffer(respBody))
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf("internal-error: unimplemented unmarshal function for content type %q", contentType)
 }
 
 // Client is a base client to be used by API-specific clients. It satisfies the BaseClient interface.

--- a/sdk/client/client_test.go
+++ b/sdk/client/client_test.go
@@ -4,9 +4,14 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/internal/test"
@@ -46,4 +51,234 @@ func TestAccClient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExecutePaged(): %v", err)
 	}
+}
+
+func TestMarshalByteStreamAndPowerShell(t *testing.T) {
+	contentTypes := []string{
+		"application/octet-stream",
+		"text/powershell",
+	}
+	value := []byte("What is my purpose?")
+	for _, contentType := range contentTypes {
+		r := &Request{
+			Request: &http.Request{
+				Header: map[string][]string{
+					"Content-Type": {contentType},
+				},
+			},
+		}
+		if err := r.Marshal(&value); err != nil {
+			t.Fatalf("marshaling: %+v", err)
+		}
+
+		err := unmarshalResponse(r.Body, func(in []byte) error {
+			out := string(in)
+			if out != "What is my purpose?" {
+				return fmt.Errorf("expected the marshalled response to match `What is my purpose?` but got %q", out)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("validating marshaled value: %+v", err)
+		}
+	}
+}
+
+func TestMarshalJson(t *testing.T) {
+	type sampleObj struct {
+		Name   string `json:"name"`
+		Animal string `json:"animal"`
+	}
+	type payload struct {
+		Inner sampleObj `json:"inner"`
+	}
+
+	val := payload{
+		Inner: sampleObj{
+			Name:   "tabatha",
+			Animal: "cat",
+		},
+	}
+	r := &Request{
+		Request: &http.Request{
+			Header: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+		},
+	}
+	if err := r.Marshal(&val); err != nil {
+		t.Fatalf("marshaling: %+v", err)
+	}
+
+	var unmarshaled payload
+	err := unmarshalResponse(r.Body, func(in []byte) error {
+		if e := json.Unmarshal(in, &unmarshaled); e != nil {
+			return e
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unmarshaling value: %+v", err)
+	}
+	if !reflect.DeepEqual(val, unmarshaled) {
+		t.Fatalf("unexpected difference in encoded objects. First: %+v\n\nSecond: %+v", val, unmarshaled)
+	}
+}
+
+func TestMarshalXml(t *testing.T) {
+	type sampleObj struct {
+		Name   string `xml:"name"`
+		Animal string `xml:"animal"`
+	}
+	type payload struct {
+		Inner sampleObj `xml:"inner"`
+	}
+
+	contentTypes := []string{
+		"application/xml",
+		"text/xml",
+	}
+	for _, contentType := range contentTypes {
+		val := payload{
+			Inner: sampleObj{
+				Name:   "tabatha",
+				Animal: "cat",
+			},
+		}
+		r := &Request{
+			Request: &http.Request{
+				Header: map[string][]string{
+					"Content-Type": {contentType},
+				},
+			},
+		}
+		if err := r.Marshal(&val); err != nil {
+			t.Fatalf("marshaling: %+v", err)
+		}
+
+		var unmarshaled payload
+		err := unmarshalResponse(r.Body, func(in []byte) error {
+			if e := xml.Unmarshal(in, &unmarshaled); e != nil {
+				return e
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("unmarshaling value: %+v", err)
+		}
+		if !reflect.DeepEqual(val, unmarshaled) {
+			t.Fatalf("unexpected difference in encoded objects. First: %+v\n\nSecond: %+v", val, unmarshaled)
+		}
+	}
+}
+
+func TestUnmarshalByteStreamAndPowerShell(t *testing.T) {
+	contentTypes := []string{
+		"application/octet-stream",
+		"text/powershell",
+	}
+	expected := []byte("you serve butter")
+	for _, contentType := range contentTypes {
+		r := &Response{
+			Response: &http.Response{
+				Header: map[string][]string{
+					"Content-Type": {contentType},
+				},
+				Body: io.NopCloser(bytes.NewReader(expected)),
+			},
+		}
+		unmarshaled := make([]byte, 0)
+		if err := r.Unmarshal(&unmarshaled); err != nil {
+			t.Fatalf("unmarshaling: %+v", err)
+		}
+		if string(unmarshaled) != "you serve butter" {
+			t.Fatalf("unexpected difference in decoded objects. Expected %q\n\nGot: %q", string(expected), string(unmarshaled))
+		}
+	}
+}
+
+func TestUnmarshalJson(t *testing.T) {
+	type sampleObj struct {
+		Name   string `json:"name"`
+		Animal string `json:"animal"`
+	}
+	type payload struct {
+		Inner sampleObj `json:"inner"`
+	}
+	expected := payload{
+		Inner: sampleObj{
+			Name:   "tabatha",
+			Animal: "cat",
+		},
+	}
+	input, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("preparing source data for unmarshaling: %+v", err)
+	}
+	r := &Response{
+		Response: &http.Response{
+			Header: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+			Body: io.NopCloser(bytes.NewReader(input)),
+		},
+	}
+	var unmarshaled payload
+	if err := r.Unmarshal(&unmarshaled); err != nil {
+		t.Fatalf("unmarshaling value: %+v", err)
+	}
+	if !reflect.DeepEqual(expected, unmarshaled) {
+		t.Fatalf("unexpected difference in decoded objects. Expected %q\n\nGot: %+v", expected, unmarshaled)
+	}
+}
+
+func TestUnmarshalXml(t *testing.T) {
+	type sampleObj struct {
+		Name   string `xml:"name"`
+		Animal string `xml:"animal"`
+	}
+	type payload struct {
+		Inner sampleObj `xml:"inner"`
+	}
+	contentTypes := []string{
+		"application/xml",
+		"text/xml",
+	}
+	expected := payload{
+		Inner: sampleObj{
+			Name:   "tabatha",
+			Animal: "cat",
+		},
+	}
+	for _, contentType := range contentTypes {
+		input, err := xml.Marshal(expected)
+		if err != nil {
+			t.Fatalf("preparing source data for unmarshaling: %+v", err)
+		}
+		r := &Response{
+			Response: &http.Response{
+				Header: map[string][]string{
+					"Content-Type": {contentType},
+				},
+				Body: io.NopCloser(bytes.NewReader(input)),
+			},
+		}
+		var unmarshaled payload
+		if err := r.Unmarshal(&unmarshaled); err != nil {
+			t.Fatalf("unmarshaling value: %+v", err)
+		}
+		if !reflect.DeepEqual(expected, unmarshaled) {
+			t.Fatalf("unexpected difference in decoded objects. Expected %q\n\nGot: %+v", expected, unmarshaled)
+		}
+	}
+}
+
+func unmarshalResponse(body io.ReadCloser, unmarshal func(in []byte) error) error {
+	respBody, err := io.ReadAll(body)
+	if err != nil {
+		return fmt.Errorf("parsing response body: %+v", err)
+	}
+	body.Close()
+
+	return unmarshal(respBody)
 }

--- a/sdk/client/client_test.go
+++ b/sdk/client/client_test.go
@@ -9,12 +9,12 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"io"
 	"net/http"
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/sdk/internal/test"
 )
 

--- a/sdk/client/client_test.go
+++ b/sdk/client/client_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"io"
 	"net/http"
 	"reflect"
@@ -187,12 +188,12 @@ func TestUnmarshalByteStreamAndPowerShell(t *testing.T) {
 				Body: io.NopCloser(bytes.NewReader(expected)),
 			},
 		}
-		unmarshaled := make([]byte, 0)
+		var unmarshaled = pointer.To(make([]byte, 0))
 		if err := r.Unmarshal(&unmarshaled); err != nil {
 			t.Fatalf("unmarshaling: %+v", err)
 		}
-		if string(unmarshaled) != "you serve butter" {
-			t.Fatalf("unexpected difference in decoded objects. Expected %q\n\nGot: %q", string(expected), string(unmarshaled))
+		if string(*unmarshaled) != "you serve butter" {
+			t.Fatalf("unexpected difference in decoded objects. Expected %q\n\nGot: %q", string(expected), string(*unmarshaled))
 		}
 	}
 }


### PR DESCRIPTION
This PR adds support for requests and responses containing `[]byte`'s - and also supports for marshaling and unmarshaling bodies containing powershell scripts which are defined as a byte array.

Supersedes #298 