### PR TITLE
`client/sdk`: fix `*[]bytes` response unmarshal may panic when set by reflect

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -207,7 +207,7 @@ func (r *Response) Unmarshal(model interface{}) error {
 	if strings.Contains(contentType, "application/octet-stream") || strings.Contains(contentType, "text/powershell") {
 		ptr, ok := model.(**[]byte)
 		if !ok || ptr == nil {
-			return fmt.Errorf("internal-error: `model` must be **[]byte not not nil but got %+v", model)
+			return fmt.Errorf("internal-error: `model` must be a non-nil `**[]byte` but got %+v", model)
 		}
 
 		// Read the response body and close it

--- a/sdk/client/client_test.go
+++ b/sdk/client/client_test.go
@@ -198,6 +198,34 @@ func TestUnmarshalByteStreamAndPowerShell(t *testing.T) {
 	}
 }
 
+func TestUnmarshalByteStreamAndPowerShellWithModel(t *testing.T) {
+	contentTypes := []string{
+		"application/octet-stream",
+		"text/powershell",
+	}
+	var respModel = struct {
+		HttpResponse *http.Response
+		Model        *[]byte
+	}{}
+	expected := []byte("you serve butter")
+	for _, contentType := range contentTypes {
+		r := &Response{
+			Response: &http.Response{
+				Header: map[string][]string{
+					"Content-Type": {contentType},
+				},
+				Body: io.NopCloser(bytes.NewReader(expected)),
+			},
+		}
+		if err := r.Unmarshal(&respModel.Model); err != nil {
+			t.Fatalf("unmarshaling: %+v", err)
+		}
+		if string(*respModel.Model) != "you serve butter" {
+			t.Fatalf("unexpected difference in decoded objects. Expected %q\n\nGot: %q", string(expected), string(*respModel.Model))
+		}
+	}
+}
+
 func TestUnmarshalJson(t *testing.T) {
 	type sampleObj struct {
 		Name   string `json:"name"`


### PR DESCRIPTION
add a unit test to simulate the real sdk behavior in automation sdk, it will panic as below. change to use pointer assignment instead of using reflect. 

https://github.com/hashicorp/go-azure-sdk/blob/e4eafebf7f182d142a29653e55d6865ca39f9bc2/resource-manager/automation/2022-08-08/dscconfiguration/method_getcontent.go#L47-L49

```
panic: reflect: call of reflect.Value.SetBytes on zero Value [recovered]
	panic: reflect: call of reflect.Value.SetBytes on zero Value
goroutine 19 [running]:
testing.tRunner.func1.2({0x7115c0, 0xc00012c1e0})
	/home/wuxu/.go/.versions/1.19.5/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
	/home/wuxu/.go/.versions/1.19.5/src/testing/testing.go:1399 +0x39f
panic({0x7115c0, 0xc00012c1e0})
	/home/wuxu/.go/.versions/1.19.5/src/runtime/panic.go:884 +0x212
reflect.flag.mustBeAssignableSlow(0xc000186420?)
	/home/wuxu/.go/.versions/1.19.5/src/reflect/value.go:253 +0x116
reflect.flag.mustBeAssignable(...)
	/home/wuxu/.go/.versions/1.19.5/src/reflect/value.go:247
reflect.Value.SetBytes({0x0?, 0x0?, 0x76ec14?}, {0xc0001cc000, 0x10, 0x200})
	/home/wuxu/.go/.versions/1.19.5/src/reflect/value.go:2183 +0x5c
github.com/hashicorp/go-azure-sdk/sdk/client.(*Response).Unmarshal(0xc000167e50, {0x6f7420, 0xc000119228})
	/home/wuxu/azure/go-azure-sdk/sdk/client/client.go:224 +0x955
github.com/hashicorp/go-azure-sdk/sdk/client.TestUnmarshalByteStreamAndPowerShellWithModel(0xc0001031e0)

```

related: #445