### PR TITLE
sdk: explicitly setting Min TLS to 1.2

### DIFF
--- a/sdk/auth/client.go
+++ b/sdk/auth/client.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"context"
+	"crypto/tls"
 	"log"
 	"math"
 	"net"
@@ -101,6 +102,9 @@ func httpClient(params httpClientParams) *http.Client {
 	r.RetryWaitMin = params.retryWaitMin
 	r.RetryWaitMax = params.retryWaitMax
 
+	tlsConfig := tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 	r.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			Proxy: proxyFunc,
@@ -110,6 +114,7 @@ func httpClient(params httpClientParams) *http.Client {
 			},
 			MaxIdleConns:          100,
 			IdleConnTimeout:       90 * time.Second,
+			TLSClientConfig:       &tlsConfig,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 			ForceAttemptHTTP2:     true,

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -6,6 +6,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -547,6 +548,9 @@ func (c *Client) retryableClient(checkRetry retryablehttp.CheckRetry) (r *retrya
 	r.ErrorHandler = RetryableErrorHandler
 	r.Logger = log.Default()
 
+	tlsConfig := tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 	r.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
@@ -554,6 +558,7 @@ func (c *Client) retryableClient(checkRetry retryablehttp.CheckRetry) (r *retrya
 				d := &net.Dialer{Resolver: &net.Resolver{}}
 				return d.DialContext(ctx, network, addr)
 			},
+			TLSClientConfig:       &tlsConfig,
 			MaxIdleConns:          100,
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,


### PR DESCRIPTION
This is defaulted in Go as of 1.18: https://go.dev/doc/go1.18#tls10 however there's no harm in being explicit