### PR TITLE
sdk/client: raising an error when lro operation failed or cancelled

### DIFF
--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -178,10 +178,8 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 		}
 
 		if result.Status == pollers.PollingStatusFailed {
-			apiResponse := http.Response{
-				Body: io.NopCloser(bytes.NewReader(respBody)),
-			}
-			lroError, parseError := parseErrorFromApiResponse(apiResponse)
+			result.HttpResponse.Body = io.NopCloser(bytes.NewReader(respBody))
+			lroError, parseError := parseErrorFromApiResponse(*result.HttpResponse.Response)
 			if parseError != nil {
 				return nil, parseError
 			}
@@ -193,10 +191,8 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 		}
 
 		if result.Status == pollers.PollingStatusCancelled {
-			apiResponse := http.Response{
-				Body: io.NopCloser(bytes.NewReader(respBody)),
-			}
-			lroError, parseError := parseErrorFromApiResponse(apiResponse)
+			result.HttpResponse.Body = io.NopCloser(bytes.NewReader(respBody))
+			lroError, parseError := parseErrorFromApiResponse(*result.HttpResponse.Response)
 			if parseError != nil {
 				return nil, parseError
 			}

--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -179,12 +179,14 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 		if result.Status == pollers.PollingStatusFailed {
 			err = pollers.PollingFailedError{
 				HttpResponse: result.HttpResponse,
+				Message:      string(respBody),
 			}
 		}
 
 		if result.Status == pollers.PollingStatusCancelled {
 			err = pollers.PollingCancelledError{
 				HttpResponse: result.HttpResponse,
+				Message:      string(respBody),
 			}
 		}
 

--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -118,6 +118,8 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 		}
 		result.HttpResponse.Body.Close()
 
+		result.HttpResponse.Body = io.NopCloser(bytes.NewReader(respBody))
+
 		// update the poll interval if a Retry-After header is returned
 		if s, ok := result.HttpResponse.Header["Retry-After"]; ok {
 			if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
@@ -178,7 +180,6 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 		}
 
 		if result.Status == pollers.PollingStatusFailed {
-			result.HttpResponse.Body = io.NopCloser(bytes.NewReader(respBody))
 			lroError, parseError := parseErrorFromApiResponse(*result.HttpResponse.Response)
 			if parseError != nil {
 				return nil, parseError
@@ -191,7 +192,6 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 		}
 
 		if result.Status == pollers.PollingStatusCancelled {
-			result.HttpResponse.Body = io.NopCloser(bytes.NewReader(respBody))
 			lroError, parseError := parseErrorFromApiResponse(*result.HttpResponse.Response)
 			if parseError != nil {
 				return nil, parseError


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/21870
to change the error mesage to:
```
=== CONT  TestAccAppConfiguration_standard
    testcase.go:110: Step 1/2 error: Error running apply: exit status 1
        
        Error: creating Configuration Store (Subscription: "xxx"
        Resource Group Name: "acctestRG-appconfig-230522161800054336"
        Configuration Store Name: "appConf1"): polling after Create: polling failed: {"id":"/subscriptions/xxx/providers/Microsoft.AppConfiguration/locations/westeurope/operationsStatus/exSCtZucYyDRejH0Qry3U2xmdvGTx3yogpJ1TObVtSQ","name":"exSCtZucYyDRejH0Qry3U2xmdvGTx3yogpJ1TObVtSQ","status":"Failed","error":{"code":"NameUnavailable","message":"The specified name is already in use.","additionalInfo":[{"type":"ActivityId","info":{"activityId":"0ddb9e62-9386-4040-8f3e-605fb2647d1f"}}]}}
        
          with azurerm_app_configuration.test,
          on terraform_plugin_test.tf line 22, in resource "azurerm_app_configuration" "test":
          22: resource "azurerm_app_configuration" "test" {
        

```