### PR TITLE
sdk/client/resourcemanager: parsing error messages from API Responses

### DIFF
--- a/sdk/client/pollers/interface.go
+++ b/sdk/client/pollers/interface.go
@@ -6,8 +6,9 @@ package pollers
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
 )
 
 // PollerType allows custom pollers to be created to determine when a particular Operation has

--- a/sdk/client/pollers/poller.go
+++ b/sdk/client/pollers/poller.go
@@ -6,9 +6,10 @@ package pollers
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"sync"
 	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
 )
 
 const DefaultNumberOfDroppedConnectionsToAllow = 3

--- a/sdk/client/resourcemanager/errors.go
+++ b/sdk/client/resourcemanager/errors.go
@@ -1,0 +1,129 @@
+package resourcemanager
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+var _ error = Error{}
+
+type Error struct {
+	ActivityId string
+	Code       string
+	Message    string
+	Status     string
+
+	FullHttpBody string
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf(`the Azure API returned the following error:
+
+Status: %q
+Code: %q
+Message: %q
+Activity Id: %q
+
+---
+
+API Response:
+
+----[start]----
+%s
+-----[end]-----
+`, e.Status, e.Code, e.Message, e.ActivityId, e.FullHttpBody)
+}
+
+// parseErrorFromApiResponse parses the error from the API Response
+// into an Error type, which allows for better surfacing of errors
+func parseErrorFromApiResponse(response http.Response) (*Error, error) {
+	respBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("parsing response body: %+v", err)
+	}
+	response.Body.Close()
+
+	respBody = bytes.TrimPrefix(respBody, []byte("\xef\xbb\xbf"))
+	response.Body = io.NopCloser(bytes.NewBuffer(respBody))
+
+	// there's a number of internal Azure error types, we should attempt unmarshalling into each
+	// for now we're implementing the simple case we can add to
+	var err1 lroErrorType1
+	if err = json.Unmarshal(respBody, &err1); err == nil && err1.Error.Code != "" && err1.Error.Message != "" {
+		e := Error{
+			Code:         err1.Error.Code,
+			Message:      err1.Error.Message,
+			Status:       err1.Status,
+			FullHttpBody: string(respBody),
+		}
+
+		// given inconsistencies between different API's, this isn't pretty, but avoids crashes whilst best-efforting it
+		for _, info := range err1.Error.AdditionalInfo {
+			additionalInfo, ok := info.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			typeVal, ok := additionalInfo["type"].(string)
+			if !ok {
+				continue
+			}
+
+			if strings.EqualFold(typeVal, "ActivityId") {
+				infoBlock, ok := additionalInfo["info"].(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				for k, v := range infoBlock {
+					if strings.EqualFold(k, "ActivityId") {
+						if val, ok := v.(string); ok {
+							e.ActivityId = val
+						}
+					}
+				}
+			}
+		}
+
+		return &e, nil
+	}
+
+	var err2 resourceManagerErrorType1
+	if err = json.Unmarshal(respBody, &err2); err == nil && err2.Code != "" && err2.Message != "" {
+		return &Error{
+			Code:         err2.Code,
+			Message:      err2.Message,
+			Status:       "Unknown",
+			FullHttpBody: string(respBody),
+		}, nil
+	}
+
+	return &Error{
+		Code:         "internal-error",
+		Message:      "Couldn't parse Azure API Response into a friendly error - please see the original HTTP Response for more details (and file a bug so we can fix this!).",
+		Status:       "Unknown",
+		FullHttpBody: string(respBody),
+	}, nil
+}
+
+type lroErrorType1 struct {
+	Error struct {
+		Code           string        `json:"code"`
+		Message        string        `json:"message"`
+		AdditionalInfo []interface{} `json:"additionalInfo"`
+	} `json:"error"`
+	Status string `json:"status"`
+}
+
+type resourceManagerErrorType1 struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Details []struct {
+		Message string `json:"message,omitempty"`
+		Code    string `json:"code,omitempty"`
+	} `json:"details"`
+}

--- a/sdk/client/resourcemanager/errors_test.go
+++ b/sdk/client/resourcemanager/errors_test.go
@@ -1,0 +1,182 @@
+package resourcemanager
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestParseErrorFromApiResponse_LongRunningOperation(t *testing.T) {
+	// LRO specific response
+	body := `{"id":"/subscriptions/xxx/providers/Microsoft.AppConfiguration/locations/westeurope/operationsStatus/exSCtZucYyDRejH0Qry3U2xmdvGTx3yogpJ1TObVtSQ","name":"exSCtZucYyDRejH0Qry3U2xmdvGTx3yogpJ1TObVtSQ","status":"Failed","error":{"code":"NameUnavailable","message":"The specified name is already in use.","additionalInfo":[{"type":"ActivityId","info":{"activityId":"0ddb9e62-9386-4040-8f3e-605fb2647d1f"}}]}}`
+	input := http.Response{
+		Body: io.NopCloser(bytes.NewReader([]byte(body))),
+	}
+	expected := Error{
+		ActivityId:   "0ddb9e62-9386-4040-8f3e-605fb2647d1f",
+		Code:         "NameUnavailable",
+		FullHttpBody: body,
+		Message:      "The specified name is already in use.",
+		Status:       "Failed",
+	}
+	actual, err := parseErrorFromApiResponse(input)
+	if err != nil {
+		t.Fatalf("parsing error from api response: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil")
+	}
+	if !reflect.DeepEqual(*actual, expected) {
+		t.Fatalf("expected and actual didn't match. Expected: %+v\n\n Actual: %+v", expected, actual)
+	}
+}
+
+func TestParseErrorFromApiResponse_ResourceManager(t *testing.T) {
+	// Resource Manager specific response from https://github.com/hashicorp/terraform-provider-azurerm/issues/10858
+	body := `{"Code":"Conflict","Message":"Cannot update the site 'func-tfbug-b78d100425' because it uses AlwaysOn feature which is not allowed in the target compute mode.","Target":null,"Details":[{"Message":"Cannot update the site 'func-tfbug-b78d100425' because it uses AlwaysOn feature which is not allowed in the target compute mode."},{"Code":"Conflict"},{"ErrorEntity":{"ExtendedCode":"04068","MessageTemplate":"Cannot update the site '{0}' because it uses AlwaysOn feature which is not allowed in the target compute mode.","Parameters":["func-tfbug-b78d100425"],"Code":"Conflict","Message":"Cannot update the site 'func-tfbug-b78d100425' because it uses AlwaysOn feature which is not allowed in the target compute mode."}}],"Innererror":null}`
+	input := http.Response{
+		Body: io.NopCloser(bytes.NewReader([]byte(body))),
+	}
+	expected := Error{
+		ActivityId:   "",
+		Code:         "Conflict",
+		FullHttpBody: body,
+		Message:      "Cannot update the site 'func-tfbug-b78d100425' because it uses AlwaysOn feature which is not allowed in the target compute mode.",
+		Status:       "Unknown",
+	}
+	actual, err := parseErrorFromApiResponse(input)
+	if err != nil {
+		t.Fatalf("parsing error from api response: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil")
+	}
+	if !reflect.DeepEqual(*actual, expected) {
+		t.Fatalf("expected and actual didn't match. Expected: %+v\n\n Actual: %+v", expected, actual)
+	}
+}
+
+func TestParseErrorFromApiResponse_EmptyResponseShouldOutputHttpResponseAnyway(t *testing.T) {
+	body := ``
+	input := http.Response{
+		Body: io.NopCloser(bytes.NewReader([]byte(body))),
+	}
+	expected := Error{
+		ActivityId:   "",
+		Code:         "internal-error",
+		FullHttpBody: body,
+		Message:      "Couldn't parse Azure API Response into a friendly error - please see the original HTTP Response for more details (and file a bug so we can fix this!).",
+		Status:       "Unknown",
+	}
+	actual, err := parseErrorFromApiResponse(input)
+	if err != nil {
+		t.Fatalf("parsing error from api response: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil")
+	}
+	if !reflect.DeepEqual(*actual, expected) {
+		t.Fatalf("expected and actual didn't match. Expected: %+v\n\n Actual: %+v", expected, actual)
+	}
+}
+
+func TestParseErrorFromApiResponse_UnexpectedHtmlShouldOutputHttpResponseAnyway(t *testing.T) {
+	// example from https://github.com/hashicorp/terraform-provider-azurerm/issues/11491
+	body := `<!DOCTYPE html><html>    <head>        <title>Runtime Error</title>        <meta name="viewport" content="width=device-width" />        <style>         body {font-family:"Verdana";font-weight:normal;font-size: .7em;color:black;}          p {font-family:"Verdana";font-weight:normal;color:black;margin-top: -5px}         b {font-family:"Verdana";font-weight:bold;color:black;margin-top: -5px}         H1 { font-family:"Verdana";font-weight:normal;font-size:18pt;color:red }         H2 { font-f`
+	input := http.Response{
+		Body: io.NopCloser(bytes.NewReader([]byte(body))),
+	}
+	expected := Error{
+		ActivityId:   "",
+		Code:         "internal-error",
+		FullHttpBody: body,
+		Message:      "Couldn't parse Azure API Response into a friendly error - please see the original HTTP Response for more details (and file a bug so we can fix this!).",
+		Status:       "Unknown",
+	}
+	actual, err := parseErrorFromApiResponse(input)
+	if err != nil {
+		t.Fatalf("parsing error from api response: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil")
+	}
+	if !reflect.DeepEqual(*actual, expected) {
+		t.Fatalf("expected and actual didn't match. Expected: %+v\n\n Actual: %+v", expected, actual)
+	}
+}
+
+func TestParseErrorFromApiResponse_UnexpectedLiteralStringShouldOutputHttpResponseAnyway(t *testing.T) {
+	// example from https://github.com/hashicorp/terraform-provider-azurerm/issues/1775#issuecomment-927765831
+	body := `For first party solution, the solution name has to be convention of solutionType(workspaceName), and the product has to be OMSGallery/solutionType.  For example, product OMSGallery/ChangeTracking, solution name ChangeTracking(myworkspace)`
+	input := http.Response{
+		Body: io.NopCloser(bytes.NewReader([]byte(body))),
+	}
+	expected := Error{
+		ActivityId:   "",
+		Code:         "internal-error",
+		FullHttpBody: body,
+		Message:      "Couldn't parse Azure API Response into a friendly error - please see the original HTTP Response for more details (and file a bug so we can fix this!).",
+		Status:       "Unknown",
+	}
+	actual, err := parseErrorFromApiResponse(input)
+	if err != nil {
+		t.Fatalf("parsing error from api response: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil")
+	}
+	if !reflect.DeepEqual(*actual, expected) {
+		t.Fatalf("expected and actual didn't match. Expected: %+v\n\n Actual: %+v", expected, actual)
+	}
+}
+
+func TestParseErrorFromApiResponse_UnexpectedLiteralQuotedStringShouldOutputHttpResponseAnyway(t *testing.T) {
+	// example from https://github.com/hashicorp/terraform-provider-azurerm/issues/1775#issuecomment-700385311
+	body := `"Solution Not Found : solutionType ADReplication, workspace la-operations-vjhywhmlbmndfroveecsjfkilkkkwswrkoyyggulnwpcaxdni"`
+	input := http.Response{
+		Body: io.NopCloser(bytes.NewReader([]byte(body))),
+	}
+	expected := Error{
+		ActivityId:   "",
+		Code:         "internal-error",
+		FullHttpBody: body,
+		Message:      "Couldn't parse Azure API Response into a friendly error - please see the original HTTP Response for more details (and file a bug so we can fix this!).",
+		Status:       "Unknown",
+	}
+	actual, err := parseErrorFromApiResponse(input)
+	if err != nil {
+		t.Fatalf("parsing error from api response: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil")
+	}
+	if !reflect.DeepEqual(*actual, expected) {
+		t.Fatalf("expected and actual didn't match. Expected: %+v\n\n Actual: %+v", expected, actual)
+	}
+}
+
+func TestParseErrorFromApiResponse_UnexpectedShouldOutputHttpResponseAnyway(t *testing.T) {
+	body := `{"something-went": "wrong"}`
+	input := http.Response{
+		Body: io.NopCloser(bytes.NewReader([]byte(body))),
+	}
+	expected := Error{
+		ActivityId:   "",
+		Code:         "internal-error",
+		FullHttpBody: body,
+		Message:      "Couldn't parse Azure API Response into a friendly error - please see the original HTTP Response for more details (and file a bug so we can fix this!).",
+		Status:       "Unknown",
+	}
+	actual, err := parseErrorFromApiResponse(input)
+	if err != nil {
+		t.Fatalf("parsing error from api response: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil")
+	}
+	if !reflect.DeepEqual(*actual, expected) {
+		t.Fatalf("expected and actual didn't match. Expected: %+v\n\n Actual: %+v", expected, actual)
+	}
+}


### PR DESCRIPTION
This PR lays the foundation for solving a number of issues within `hashicorp/terraform-provider-azurerm` by providing a function which parses the Azure Error from the API Response for both Long Running Operations and regular Resource Manager operations.

There's a considerable number of different formats for error messages, so this isn't going to be necessarily be conclusive, hence falling back to a generic error message showing the API body if we can't parse it.

A random selection of issues this'll ultimately end up fixing:

* https://github.com/hashicorp/terraform-provider-azurerm/issues/1775
* https://github.com/Azure/azure-rest-api-specs/issues/9672
* https://github.com/hashicorp/terraform-provider-azurerm/issues/11491
* https://github.com/hashicorp/terraform-provider-azurerm/issues/16103
* https://github.com/hashicorp/terraform-provider-azurerm/issues/14941
* https://github.com/hashicorp/terraform-provider-azurerm/issues/12770
* https://github.com/hashicorp/terraform-provider-azurerm/issues/2339
* https://github.com/hashicorp/terraform-provider-azurerm/issues/10858

Notes:

1. This change will only applicable when using the new base layer
2. This change needs to be threaded through into Long Running Operations (as a part of #479)
3. This change needs to be threaded through into Resource Manager Operations (in a follow-up PR)

I'm intentionally splitting this PR out (so this PR is functionally not useful at this point) since it's needed for #479 (as well as needs to be threaded through the Resource Manager error parsing)