### PR TITLE
base client: align msgraph instantiator func with resourcemanager

### DIFF
--- a/sdk/client/msgraph/client.go
+++ b/sdk/client/msgraph/client.go
@@ -35,13 +35,13 @@ type Client struct {
 	tenantId string
 }
 
-func NewMsGraphClient(api environments.Api, apiVersion ApiVersion) (*Client, error) {
+func NewMsGraphClient(api environments.Api, serviceName string, apiVersion ApiVersion) (*Client, error) {
 	endpoint, ok := api.Endpoint()
 	if !ok {
 		return nil, fmt.Errorf("no `endpoint` was returned for this environment")
 	}
 	baseUri := fmt.Sprintf("%s/%s", *endpoint, apiVersion)
-	baseClient := client.NewClient(baseUri, "MicrosoftGraph", string(apiVersion))
+	baseClient := client.NewClient(baseUri, fmt.Sprintf("MicrosoftGraph-%s", serviceName), string(apiVersion))
 	return &Client{
 		Client:        baseClient,
 		EnableRetries: true,

--- a/sdk/client/msgraph/client_test.go
+++ b/sdk/client/msgraph/client_test.go
@@ -44,7 +44,7 @@ func TestNewGetRequest(t *testing.T) {
 		Path:          "/applications",
 	}
 	localApi := environments.NewApiEndpoint("Example", "http://localhost", pointer.To("00000000-0000-000-0000-000000000000"))
-	msGraphClient, err := msgraph.NewMsGraphClient(localApi, msgraph.VersionOnePointZero)
+	msGraphClient, err := msgraph.NewMsGraphClient(localApi, "application", msgraph.VersionOnePointZero)
 	if err != nil {
 		t.Fatalf("building client: %+v", err)
 	}


### PR DESCRIPTION
Ensuring the method arguments are compatible between clients helps to simplify the generators

<img width="992" alt="Screenshot 2023-07-04 at 19 21 41" src="https://github.com/hashicorp/go-azure-sdk/assets/251987/15ebcabe-835b-4736-9ae6-e44d8ccae22b">
