### PR TITLE
resourcemanager/poller: supporting `AnalysisServices`

### DIFF
--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -175,6 +175,8 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			// StorageSync@2020-03-01 (CloudEndpoints) returns `newReplicaGroup` rather than `InProgress` during creation/update
 			// See: https://github.com/hashicorp/go-azure-sdk/issues/565
 			"newReplicaGroup": pollers.PollingStatusInProgress,
+			// AnalysisServices @ 2017-08-01 (Servers) returns `Provisioning` during Creation
+			"Provisioning": pollers.PollingStatusInProgress,
 		}
 		for k, v := range statuses {
 			if strings.EqualFold(string(op.Properties.ProvisioningState), string(k)) {


### PR DESCRIPTION
This service returns `Provisioning` instead of `InProgress`:

```
 Error: creating Server (Subscription: "*******"
        Resource Group Name: "acctestRG-analysis-230731093230507793"
        Server Name: "acctestass230731093230507793"): polling after Create: `result.Status` was nil/empty - `op.Status` was "Provisioning" / `op.Properties.ProvisioningState` was ""
```

This PR fixes this test:

```
 -run=TestAccAnalysisServicesServer_basic -timeout=60m
=== RUN   TestAccAnalysisServicesServer_basic
=== PAUSE TestAccAnalysisServicesServer_basic
=== CONT  TestAccAnalysisServicesServer_basic
--- PASS: TestAccAnalysisServicesServer_basic (173.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/analysisservices	174.813s
```