### PR TITLE
sdk/client: fixing an issue when parsing the OData from the API Response

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -352,10 +352,9 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 				return true, nil
 			}
 
-			o, err := odata.FromResponse(r)
-			if err != nil {
-				return false, err
-			}
+			// Extract OData from response, intentionally ignoring any errors as it's not crucial to extract
+			// valid OData at this point (valid json can still error here, such as any non-object literal)
+			o, _ := odata.FromResponse(r)
 
 			if f := req.RetryFunc; f != nil {
 				shouldRetry, err := f(r, o)

--- a/sdk/client/resourcemanager/poller_delete.go
+++ b/sdk/client/resourcemanager/poller_delete.go
@@ -88,12 +88,16 @@ func (p deletePoller) Poll(ctx context.Context) (result *pollers.PollResult, err
 	if resp.Response != nil {
 		switch resp.StatusCode {
 		case http.StatusNotFound:
-			result.Status = pollers.PollingStatusSucceeded
-			return
+			{
+				result.Status = pollers.PollingStatusSucceeded
+				return
+			}
 
 		case http.StatusOK:
-			result.Status = pollers.PollingStatusInProgress
-			return
+			{
+				result.Status = pollers.PollingStatusInProgress
+				return
+			}
 		}
 
 		err = fmt.Errorf("unexpected status code when polling for resource after deletion, expected a 200/204 but got %d", resp.StatusCode)


### PR DESCRIPTION
Databricks @ 2023-02-01 returns a literal empty string from the initial Delete operation: https://github.com/hashicorp/go-azure-sdk/issues/436