### PR TITLE
client/resourcemanager: handling self-referenced LROs

### DIFF
--- a/sdk/client/resourcemanager/poller.go
+++ b/sdk/client/resourcemanager/poller.go
@@ -6,6 +6,7 @@ package resourcemanager
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
@@ -17,11 +18,14 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 		return pollers.Poller{}, fmt.Errorf("no HTTP Response was returned")
 	}
 
+	originalRequestUri := response.Request.URL.String()
+
 	// If this is a LRO we should either have a 201/202 with a Polling URI header
 	isLroStatus := response.StatusCode == http.StatusCreated || response.StatusCode == http.StatusAccepted
 	methodIsDelete := strings.EqualFold(response.Request.Method, "DELETE")
 	lroPollingUri := pollingUriForLongRunningOperation(response)
-	if isLroStatus && lroPollingUri != "" && !methodIsDelete {
+	lroIsSelfReference := isLROSelfReference(lroPollingUri, originalRequestUri)
+	if isLroStatus && lroPollingUri != "" && !methodIsDelete && !lroIsSelfReference {
 		lro, lroErr := longRunningOperationPollerFromResponse(response, client.Client)
 		if lroErr != nil {
 			err = lroErr
@@ -62,4 +66,21 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 	}
 
 	return pollers.Poller{}, fmt.Errorf("no applicable pollers were found for the response")
+}
+
+func isLROSelfReference(lroPollingUri, originalRequestUri string) bool {
+	// Some APIs return a LRO URI of themselves, meaning that we should be checking a 200 OK is returned rather
+	// than polling as usual. Automation@2022-08-08 - DSCNodeConfiguration CreateOrUpdate is one such example.
+	first, err := url.Parse(lroPollingUri)
+	if err != nil {
+		return false
+	}
+	second, err := url.Parse(originalRequestUri)
+	if err != nil {
+		return false
+	}
+
+	// The Query String can be a different API version / options and in some cases the Host
+	// is returned with `:443` - so the path should be sufficient as a check.
+	return strings.EqualFold(first.Path, second.Path)
 }


### PR DESCRIPTION
Some LROs return a 201 with the Location header as a self-reference, polling on that URI returns a 200 OK with no provisioningState or status field to poll on - as such we need to special-case to handle this.

Fixes an issue in `Automation` @ `2022-08-08` in `DSCNodeConfiguration` / `CreateOrUpdate`

Fixes https://github.com/hashicorp/terraform-provider-azurerm/pull/22781