### PR TITLE
Environments: consider an API available if it has an endpoint or a resourceIdentifier

### DIFF
--- a/sdk/environments/environment.go
+++ b/sdk/environments/environment.go
@@ -166,7 +166,7 @@ func (e *ApiEndpoint) withResourceIdentifier(identifier string) *ApiEndpoint {
 }
 
 func (e *ApiEndpoint) Available() bool {
-	return e != nil && e.endpoint != nil
+	return e != nil && (e.resourceIdentifier != nil || e.endpoint != nil)
 }
 
 func (e *ApiEndpoint) DomainSuffix() (*string, bool) {


### PR DESCRIPTION
Consider an API available if it has an endpoint or a resourceIdentifier (data plane APIs can be initialized with no endpoint)