### PR TITLE
sdk/client/resourcemanager: supporting 202's with a self reference

### DIFF
--- a/sdk/client/resourcemanager/poller.go
+++ b/sdk/client/resourcemanager/poller.go
@@ -40,13 +40,13 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 		contentType = response.Request.Header.Get("Content-Type")
 	}
 
-	statusCodesToCheckProvisioningState := response.StatusCode == http.StatusOK || response.StatusCode == http.StatusCreated
+	statusCodesToCheckProvisioningState := response.StatusCode == http.StatusOK || response.StatusCode == http.StatusCreated || (response.StatusCode == http.StatusAccepted && lroIsSelfReference)
 	contentTypeMatchesForProvisioningStateCheck := strings.Contains(strings.ToLower(contentType), "application/json")
 	methodIsApplicable := strings.EqualFold(response.Request.Method, "PATCH") ||
 		strings.EqualFold(response.Request.Method, "POST") ||
 		strings.EqualFold(response.Request.Method, "PUT")
 	if statusCodesToCheckProvisioningState && contentTypeMatchesForProvisioningStateCheck && methodIsApplicable {
-		provisioningState, provisioningStateErr := provisioningStatePollerFromResponse(response, client, DefaultPollingInterval)
+		provisioningState, provisioningStateErr := provisioningStatePollerFromResponse(response, lroIsSelfReference, client, DefaultPollingInterval)
 		if provisioningStateErr != nil {
 			err = provisioningStateErr
 			return pollers.Poller{}, fmt.Errorf("building provisioningState poller: %+v", provisioningStateErr)

--- a/sdk/client/resourcemanager/poller_test.go
+++ b/sdk/client/resourcemanager/poller_test.go
@@ -111,6 +111,26 @@ func TestNewPoller_LongRunningOperationWithSelfReference(t *testing.T) {
 			},
 			valid: true,
 		},
+		{
+			// Seen in API Management - API and API Schema
+			response: &client.Response{
+				Response: &http.Response{
+					StatusCode: http.StatusAccepted,
+					Header: http.Header{
+						http.CanonicalHeaderKey("Content-Type"): []string{"application/json"},
+						http.CanonicalHeaderKey("Location"):     []string{"https://async-url-test.local/subscriptions/1234/providers/foo/operations/6789?api-version=2020-01-01&asyncId=abc123&asyncCode=201"},
+					},
+					Request: &http.Request{
+						Method: http.MethodPut,
+						URL: func() *url.URL {
+							u, _ := url.Parse("https://async-url-test.local/subscriptions/1234/providers/foo/operations/6789?api-version=2020-01-01")
+							return u
+						}(),
+					},
+				},
+			},
+			valid: true,
+		},
 	}
 
 	for _, v := range testData {


### PR DESCRIPTION
Most of API Management returns a 202 with a self reference containing an `asynctoken`, as such if a self-reference exists then we can use this URI directly.

Fixes:

```
Error: creating/updating Api (Subscription: "*******"
        Resource Group Name: "acctestRG-230803055317928116"
        Service Name: "acctestAM-230803055317928116"
        Api: "acctestAMA-230803055317928116"): performing CreateOrUpdate: no applicable pollers were found for the response
```

From https://github.com/hashicorp/terraform-provider-azurerm/pull/22783