### PR TITLE
poller_lro: Adding more intermediate state for storage sync

### DIFF
--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -169,9 +169,10 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			"Updating": pollers.PollingStatusInProgress,
 			// StorageSync@2020-03-01 returns `validateInput`, `newPrivateDnsEntries`, `finishNewStorageSyncService` rather than `InProgress` during creation/update
 			// See: https://github.com/hashicorp/go-azure-sdk/issues/565
-			"validateInput":               pollers.PollingStatusInProgress,
-			"newPrivateDnsEntries":        pollers.PollingStatusInProgress,
-			"finishNewStorageSyncService": pollers.PollingStatusInProgress,
+			"validateInput":                    pollers.PollingStatusInProgress,
+			"newPrivateDnsEntries":             pollers.PollingStatusInProgress,
+			"newManagedIdentityCredentialStep": pollers.PollingStatusInProgress,
+			"finishNewStorageSyncService":      pollers.PollingStatusInProgress,
 			// StorageSync@2020-03-01 (CloudEndpoints) returns `newReplicaGroup` rather than `InProgress` during creation/update
 			// See: https://github.com/hashicorp/go-azure-sdk/issues/565
 			"newReplicaGroup": pollers.PollingStatusInProgress,


### PR DESCRIPTION
This is caught by: https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_STORAGE/4701?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true:

```
------- Stdout: -------
=== RUN   TestAccStorageSyncGroup_basic
=== PAUSE TestAccStorageSyncGroup_basic
=== CONT  TestAccStorageSyncGroup_basic
    testcase.go:113: Step 1/2 error: Error running apply: exit status 1
        Error: creating Storage Sync Service (Subscription: "*******"
        Resource Group Name: "acctestRG-SS-230803032141787572"
        Storage Sync Service Name: "acctest-StorageSync-230803032141787572"): polling after StorageSyncServicesCreate: `result.Status` was nil/empty - `op.Status` was "newManagedIdentityCredentialStep" / `op.Properties.ProvisioningState` was ""
          with azurerm_storage_sync.test,
          on terraform_plugin_test.tf line 26, in resource "azurerm_storage_sync" "test":
          26: resource "azurerm_storage_sync" "test" {
--- FAIL: TestAccStorageSyncGroup_basic (141.75s)
FAIL
```