### PR TITLE
client/resourcemanager: adding `Waiting` as a Provisioning State for HealthBot

### DIFF
--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -183,6 +183,8 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			"newReplicaGroup": pollers.PollingStatusInProgress,
 			// AnalysisServices @ 2017-08-01 (Servers) returns `Provisioning` during Creation
 			"Provisioning": pollers.PollingStatusInProgress,
+			// HealthBot @ 2022-08-08 (HealthBots CreateOrUpdate) returns `Working` during Creation
+			"Working": pollers.PollingStatusInProgress,
 		}
 		for k, v := range statuses {
 			if strings.EqualFold(string(op.Properties.ProvisioningState), string(k)) {


### PR DESCRIPTION
Allows `healthbot` to pass:

```
 $ https_proxy=http://localhost:8888 TF_ACC=1 go test -v ./internal/services/bot -run=TestAccBotHealthbot_basic -v -timeout=60m
=== RUN   TestAccBotHealthbot_basic
=== PAUSE TestAccBotHealthbot_basic
=== CONT  TestAccBotHealthbot_basic
--- PASS: TestAccBotHealthbot_basic (137.23s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/bot	138.093s
```