### PR TITLE
`sdk/client`: req marshal with `[]byte` instead of `*[]byte`

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -109,13 +109,16 @@ func (r *Request) Marshal(payload interface{}) error {
 	}
 
 	if strings.Contains(contentType, "application/octet-stream") || strings.Contains(contentType, "text/powershell") {
-		v, ok := payload.(*[]byte)
-		if !ok {
+		switch v := payload.(type) {
+		case *[]byte:
+			r.ContentLength = int64(len(*v))
+			r.Body = io.NopCloser(bytes.NewReader(*v))
+		case []byte:
+			r.ContentLength = int64(len(v))
+			r.Body = io.NopCloser(bytes.NewReader(v))
+		default:
 			return fmt.Errorf("internal-error: `payload` must be *[]byte but got %+v", payload)
 		}
-
-		r.ContentLength = int64(len(*v))
-		r.Body = io.NopCloser(bytes.NewReader(*v))
 		return nil
 	}
 

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -117,7 +117,7 @@ func (r *Request) Marshal(payload interface{}) error {
 			r.ContentLength = int64(len(v))
 			r.Body = io.NopCloser(bytes.NewReader(v))
 		default:
-			return fmt.Errorf("internal-error: `payload` must be *[]byte but got %+v", payload)
+			return fmt.Errorf("internal-error: `payload` must be *[]byte but got type %T", payload)
 		}
 		return nil
 	}

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -117,7 +117,7 @@ func (r *Request) Marshal(payload interface{}) error {
 			r.ContentLength = int64(len(v))
 			r.Body = io.NopCloser(bytes.NewReader(v))
 		default:
-			return fmt.Errorf("internal-error: `payload` must be *[]byte but got type %T", payload)
+			return fmt.Errorf("internal-error: `payload` must be []byte or *[]byte but got type %T", payload)
 		}
 		return nil
 	}


### PR DESCRIPTION
The argument for request marshal is `[]byte` not '`*[]byte` (the response is `*[]byte`)

so method below would failed with err: `performing ReplaceContent: internal-error: `payload` must be *[]byte but got [xx xx]`


https://github.com/hashicorp/go-azure-sdk/blob/32fa38105db88915b1a53cc2a590056821989a88/resource-manager/automation/2022-08-08/runbookdraft/method_replacecontent.go#L24-L40