### PR TITLE
`sdk/client` : allow content-type to not be set

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -290,7 +290,10 @@ func (c *Client) NewRequest(ctx context.Context, input RequestOptions) (*Request
 	req.Method = input.HttpMethod
 
 	req.Header = make(http.Header)
-	req.Header.Add("Content-Type", input.ContentType)
+
+	if input.ContentType != "" {
+		req.Header.Add("Content-Type", input.ContentType)
+	}
 
 	if c.UserAgent != "" {
 		req.Header.Add("User-Agent", c.UserAgent)

--- a/sdk/client/msgraph/client.go
+++ b/sdk/client/msgraph/client.go
@@ -56,6 +56,9 @@ func (c *Client) NewRequest(ctx context.Context, input client.RequestOptions) (*
 	if err := input.Validate(); err != nil {
 		return nil, fmt.Errorf("pre-validating request payload: %+v", err)
 	}
+	if input.ContentType == "" {
+		return nil, fmt.Errorf("pre-validating request payload: missing `ContentType`")
+	}
 
 	req, err := c.Client.NewRequest(ctx, input)
 	if err != nil {

--- a/sdk/client/request_options.go
+++ b/sdk/client/request_options.go
@@ -31,9 +31,6 @@ type RequestOptions struct {
 }
 
 func (ro RequestOptions) Validate() error {
-	if ro.ContentType == "" {
-		return fmt.Errorf("missing `ContentType`")
-	}
 	if len(ro.ExpectedStatusCodes) == 0 {
 		return fmt.Errorf("missing `ExpectedStatusCodes`")
 	}

--- a/sdk/client/resourcemanager/client.go
+++ b/sdk/client/resourcemanager/client.go
@@ -42,6 +42,9 @@ func (c *Client) NewRequest(ctx context.Context, input client.RequestOptions) (*
 	if err := input.Validate(); err != nil {
 		return nil, fmt.Errorf("pre-validating request payload: %+v", err)
 	}
+	if input.ContentType == "" {
+		return nil, fmt.Errorf("pre-validating request payload: missing `ContentType`")
+	}
 
 	req, err := c.Client.NewRequest(ctx, input)
 	if err != nil {


### PR DESCRIPTION
Changing this after coming across this request which doesn't use a content-type: https://learn.microsoft.com/en-us/rest/api/storageservices/get-file