### PR TITLE
`poller_lro` : add pending status `Resuming` and `Scaling` for `anaylsisservices`

### DIFF
--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -183,6 +183,10 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			"newReplicaGroup": pollers.PollingStatusInProgress,
 			// AnalysisServices @ 2017-08-01 (Servers) returns `Provisioning` during Creation
 			"Provisioning": pollers.PollingStatusInProgress,
+			// AnalysisServices @ 2017-08-01 (Servers Resume) returns `Resuming` during Update
+			"Resuming": pollers.PollingStatusInProgress,
+			// AnalysisServices @ 2017-08-01 (Servers Suspend) returns `Scaling` during Update
+			"Scaling": pollers.PollingStatusInProgress,
 			// HealthBot @ 2022-08-08 (HealthBots CreateOrUpdate) returns `Working` during Creation
 			"Working": pollers.PollingStatusInProgress,
 		}


### PR DESCRIPTION
Since the test `TestAccAzureRMAnalysisServicesServer_suspended` fails with the following errors, I assume that we should add more pending status `Resuming` and `Scaling` for `anaylsisservices`, correct?    

```
        Error: starting Server (Subscription: "..."
        Resource Group Name: "acctestRG-analysis-230807094726498046"
        Server Name: "acctestass230807094726498046"): polling after Resume: `result.Status` was nil/empty - `op.Status` was "Resuming" / `op.Properties.ProvisioningState` was ""
        
          with azurerm_analysis_services_server.test,
          on terraform_plugin_test.tf line 26, in resource "azurerm_analysis_services_server" "test":
          26: resource "azurerm_analysis_services_server" "test" {
```        
```
        Error: updating Server (Subscription: "..."
        Resource Group Name: "acctestRG-analysis-230807133137055663"
        Server Name: "acctestass230807133137055663"): polling after Update: `result.Status` was nil/empty - `op.Status` was "Scaling" / `op.Properties.ProvisioningState` was ""
        
          with azurerm_analysis_services_server.test,
          on terraform_plugin_test.tf line 26, in resource "azurerm_analysis_services_server" "test":
          26: resource "azurerm_analysis_services_server" "test" {
```

See below for more details:
```
POST /subscriptions/.../resourceGroups/acctestRG-analysis-230807142939015609/providers/Microsoft.AnalysisServices/servers/acctestass230807142939015609/resume?api-version=2017-08-01 HTTP/1.1

GET /subscriptions/.../providers/Microsoft.AnalysisServices/locations/eastus/operationstatuses/A4D50285-E6EB-47FD-A7F2-9FAD85C7190B?api-version=2016-05-16 HTTP/1.1

GET Response:
{"id":"/subscriptions/.../locations/eastus/operationstatuses/A4D50285-E6EB-47FD-A7F2-9FAD85C7190B","name":"A4D50285-E6EB-47FD-A7F2-9FAD85C7190B","status":"Resuming","startTime":"2023-08-07T04:08:38.1600000Z"}

```

```
POST /subscriptions/.../resourceGroups/acctestRG-analysis-230807142939015609/providers/Microsoft.AnalysisServices/servers/acctestass230807142939015609/suspend?api-version=2017-08-01 HTTP/1.1

GET /subscriptions/.../providers/Microsoft.AnalysisServices/locations/eastus/operationstatuses/1436F926-B485-4F41-A73F-4A5C2B21109A?api-version=2016-05-16 HTTP/1.1

GET Response:
{"id":"/subscriptions/.../locations/eastus/operationstatuses/1436F926-B485-4F41-A73F-4A5C2B21109A","name":"1436F926-B485-4F41-A73F-4A5C2B21109A","status":"Scaling","startTime":"2023-08-07T06:26:17.5300000Z"}
```
**Test result after adding pending status:**
PASS: TestAccAzureRMAnalysisServicesServer_suspended (538.88s)


