### PR TITLE
add lro status exception for DeploymentScripts

### DIFF
--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -183,6 +183,8 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			"newReplicaGroup": pollers.PollingStatusInProgress,
 			// AnalysisServices @ 2017-08-01 (Servers) returns `Provisioning` during Creation
 			"Provisioning": pollers.PollingStatusInProgress,
+			// Resources @ 2020-10-01 (DeploymentScripts) returns `ProvisioningResources` during Creation
+			"ProvisioningResources": pollers.PollingStatusInProgress,
 			// AnalysisServices @ 2017-08-01 (Servers Resume) returns `Resuming` during Update
 			"Resuming": pollers.PollingStatusInProgress,
 			// AnalysisServices @ 2017-08-01 (Servers Suspend) returns `Scaling` during Update


### PR DESCRIPTION
test failure:
```
        Error: creating Deployment Script (Subscription: "*******"
        Resource Group Name: "acctest-rg-230828001033900459"
        Deployment Script Name: "acctest-rdsac-230828001033900459"): polling after Create: `result.Status` was nil/empty - `op.Status` was "provisioningResources" / `op.Properties.ProvisioningState` was ""
          with azurerm_resource_deployment_script_azure_cli.test,
          on terraform_plugin_test.tf line 28, in resource "azurerm_resource_deployment_script_azure_cli" "test":
          28: resource "azurerm_resource_deployment_script_azure_cli" "test" {
        creating Deployment Script (Subscription:
        "*******"
        Resource Group Name: "acctest-rg-230828001033900459"
        Deployment Script Name: "acctest-rdsac-230828001033900459"): polling after
        Create: `result.Status` was nil/empty - `op.Status` was
        "provisioningResources" / `op.Properties.ProvisioningState` was ""
```

swagger enum has the `provisioningResources` value for ProvisioningState: https://github.com/Azure/azure-rest-api-specs/blob/95c0363e4cae8756c6a33b58add67776db427bbc/specification/resources/resource-manager/Microsoft.Resources/stable/2020-10-01/deploymentScripts.json#L653