### PR TITLE
tooling: support for conditionally updating the AzureRM Provider via a Tag

### DIFF
--- a/.github/workflows/automation-release.yaml
+++ b/.github/workflows/automation-release.yaml
@@ -13,6 +13,9 @@ jobs:
     runs-on: custom-linux-medium
     permissions:
       contents: write
+    outputs:
+      latest_tag: ${{ steps.results.outputs.latest_tag }}
+      should_update_azurerm: ${{ steps.results.outputs.should_update_azurerm }}
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
@@ -24,3 +27,71 @@ jobs:
       - name: "determine and publish the Git Tag"
         run: |
           ./scripts/determine-and-publish-git-tag.sh
+
+      - id: outputs
+        name: "collecting outputs"
+        run: |
+          echo "latest_tag=$(git describe --tags $(git rev-list --tags --max-count=1))" >> "$GITHUB_OUTPUT"
+          echo "should_update_azurerm=${{ github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'update-azurerm-after-release') }}" >> "$GITHUB_OUTPUT"
+
+  conditionally-update-azurerm:
+    needs: [release-go-sdk]
+    if: ${{ needs.release-go-sdk.outputs.should_update_azurerm == 'true' }}
+    runs-on: custom-linux-medium
+    outputs:
+      description: ${{ steps.update-azurerm-provider.outputs.description }}
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: ./.go-version
+
+      - name: "Launch SSH Agent"
+        run: |
+          # launch an ssh agent and export it's env vars
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        env:
+          SSH_AUTH_SOCK: /tmp/azurerm_ssh_agent.sock
+
+      - name: "Load SSH Key"
+        run: |
+          # load the Deployment Write Key for the AzureRM repository
+          echo "${{ secrets.AZURERM_DEPLOYMENT_WRITE_KEY }}" | ssh-add -
+        env:
+          SSH_AUTH_SOCK: /tmp/azurerm_ssh_agent.sock
+
+      - id: update-azurerm-provider
+        name: "Update then push the AzureRM Provider"
+        run: |
+          ./scripts/update-azurerm-provider.sh ${{ needs.release-go-sdk.outputs.latest_tag }}
+          "description=$(cat ./tmp/pr-description.txt)" >> $GITHUB_OUTPUT
+
+      - name: "Remove the Key from the SSH Agent"
+        if: always()
+        run: |
+          # remove the ssh key
+          ssh-add -D
+        env:
+          SSH_AUTH_SOCK: /tmp/azurerm_ssh_agent.sock
+
+      - name: "Terminate the SSH Agent"
+        if: always()
+        run: |
+          pkill -9 ssh-agent
+
+  conditionally-comment-on-azurerm:
+    needs: [conditionally-update-azurerm, release-go-sdk]
+    steps:
+      - name: Comment on the PR with the PR description
+        env:
+          BRANCH_NAME: "auto-pr/deps/updating-go-azure-sdk-to-${{ needs.release-go-sdk.outputs.latest_tag }}"
+          GITHUB_TOKEN: "${{ secrets.AZURERM_COMMENT_KEY }}""
+          PR_DESCRIPTION: ${{ needs.update-azurerm-provider.outputs.description }}"
+        run: |
+          echo "Sleeping 60s to give Github time to create the PR.."
+          sleep 60
+          echo "Finding the PR number.."
+          $number=gh pr list --repo="hashicorp/terraform-provider-azurerm" --search "author:hc-github-team-tf-azure sort:created-desc is:pr is:open" --json "headRefName,number" | jq '.[] | select(.headRefName=="${BRANCH_NAME}") | .number'
+          echo "Commenting on the PR"
+          gh issue comment $number --repo "hashicorp/terraform-provider-azurerm" --body "${PR_DESCRIPTION}"

--- a/.github/workflows/pr-acceptance-tests.yml
+++ b/.github/workflows/pr-acceptance-tests.yml
@@ -32,6 +32,9 @@ jobs:
     needs: [secrets-check]
     if: needs.secrets-check.outputs.available == 'true'
     steps:
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
       - name: Azure CLI login
         run: az login --allow-no-subscriptions --output none --service-principal --tenant="${{ secrets.ARM_TENANT_ID }}" --username="${{ secrets.ARM_CLIENT_ID }}" --password="${{ secrets.ARM_CLIENT_SECRET }}"
 
@@ -42,10 +45,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.21.3'
-
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+          go-version-file: ./.go-version
 
       - name: Run acceptance tests
         env:

--- a/.github/workflows/pr-unit-tests.yaml
+++ b/.github/workflows/pr-unit-tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.21.3'
+          go-version-file: ./.go-version
 
       - name: Run unit tests
         run: make test

--- a/.github/workflows/pr-validate-go-get.yaml
+++ b/.github/workflows/pr-validate-go-get.yaml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.21.3'
+          go-version-file: ./.go-version
 
       - name: "install tools / run unit tests"
         run: |

--- a/scripts/update-azurerm-provider.sh
+++ b/scripts/update-azurerm-provider.sh
@@ -29,7 +29,7 @@ function prepare {
 function runUpdaterTool {
   local workingDirectory=$1
   local newSdkVersion=$2
-  local branch="dependencies/updating-go-azure-sdk-to-${newSdkVersion}"
+  local branch="auto-deps-pr/updating-go-azure-sdk-to-${newSdkVersion}"
 
   echo "Moving into the AzureRM Provider directory.."
   pwd

--- a/scripts/update-azurerm-provider.sh
+++ b/scripts/update-azurerm-provider.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+function prepare {
+  local workingDirectory=$1
+
+  echo "Recreating the working directory at '${workingDirectory}'.."
+  rm -rf "${workingDirectory}"
+  mkdir -p "${workingDirectory}"
+
+  local repositoryDirectory="terraform-provider-azurerm"
+
+  echo "Cloning AzureRM.."
+  pushd "${workingDirectory}"
+  git clone git@github.com:hashicorp/terraform-provider-azurerm.git "${repositoryDirectory}"
+
+  echo "Configuring Git in that repository.."
+  cd "${repositoryDirectory}"
+  git config user.name "hc-github-team-tf-azure"
+  git config user.email "<>"
+
+  echo "Returning to the original directory.."
+  popd
+}
+
+function runUpdaterTool {
+  local workingDirectory=$1
+  local newSdkVersion=$2
+  local branch="dependencies/updating-go-azure-sdk-to-${newSdkVersion}"
+
+  echo "Moving into the AzureRM Provider directory.."
+  pwd
+  pushd "${workingDirectory}/terraform-provider-azurerm"
+
+  echo "Checking out a new branch.."
+  git checkout -b "${branch}"
+
+  echo "Building the updater tool.."
+  cd ./internal/tools/update-go-azure-sdk
+  go build .
+
+  echo "Running the updater tool.."
+  ./update-go-azure-sdk --new-sdk-version="${newSdkVersion}" --azurerm-repo-path=../../ --go-sdk-repo-path=../../../../ --output-file="../../../../pr-description.txt"
+
+  echo "Pushing the branch"
+  git push origin "$branch" -f
+
+  echo "Returning to the original directory"
+  popd
+}
+
+function main {
+  local workingDirectory="./tmp"
+  local goAzureSdkCheckout="$(pwd)"
+  local newSdkVersion=$1
+
+  prepare "$workingDirectory"
+  runUpdaterTool "$workingDirectory" "$newSdkVersion"
+
+  exit 0
+}
+
+# 1 = SDK Version
+main "$1"


### PR DESCRIPTION
This PR (attempts) to conditionally update the dependency in `hashicorp/terraform-provider-azurerm` whenever a release occurs in this repository, and the release pull request includes `update-azurerm-after-release`. As mentioned in https://github.com/hashicorp/terraform-provider-azurerm/pull/23498, the tool being run determines the changes in the latest SDK release and then attempts to upgrade each of the AzureRM Services to using this version.

This PR also updates the GHA's to pull the Go version from the `.go-version` file - since they weren't before.

There's an intentional sleep in this script since we need to wait for the GHA on the `hashicorp/terraform-provider-azurerm` repository to be run (to open the PR) - ~which also needs to be added before this PR can be merged~ done (~as do permissions~ done).

Dependent on https://github.com/hashicorp/terraform-provider-azurerm/pull/23498