### PR TITLE
sdk/client/resourcemanager: parsing additional details from the azure error responses where possible

### DIFF
--- a/sdk/client/resourcemanager/errors.go
+++ b/sdk/client/resourcemanager/errors.go
@@ -108,12 +108,14 @@ func parseErrorFromApiResponse(response http.Response) (*Error, error) {
 	var err3 resourceManagerErrorType2
 	if err = json.Unmarshal(respBody, &err3); err == nil && err3.Error.Code != "" && err3.Error.Message != "" {
 		activityId := ""
-		code := err3.Error.Code
+		topLevelCode := err3.Error.Code
 		messages := []string{
 			err3.Error.Message,
 		}
+		nestedCode := ""
 		for _, v := range err3.Error.Details {
-			code = v.Code
+			nestedCode = v.Code
+			messages = append(messages, v.Message)
 			if v.PossibleCauses != "" {
 				messages = append(messages, fmt.Sprintf("Possible Causes: %q", v.PossibleCauses))
 			}
@@ -127,9 +129,9 @@ func parseErrorFromApiResponse(response http.Response) (*Error, error) {
 		}
 		return &Error{
 			ActivityId:   activityId,
-			Code:         code,
+			Code:         nestedCode,
 			Message:      strings.Join(messages, "\n"),
-			Status:       "Unknown",
+			Status:       topLevelCode,
 			FullHttpBody: string(respBody),
 		}, nil
 	}

--- a/sdk/client/resourcemanager/errors_test.go
+++ b/sdk/client/resourcemanager/errors_test.go
@@ -71,8 +71,32 @@ func TestParseErrorFromApiResponse_ResourceManagerType2(t *testing.T) {
 		ActivityId:   "abc123",
 		Code:         "FailedToStartOperation",
 		FullHttpBody: body,
-		Message:      "Failed to start operation. Verify input and try operation again.\nPossible Causes: \"Invalid parameters were specified.\"\nRecommended Action: \"Verify the input and try again.\"",
-		Status:       "Unknown",
+		Message:      "Failed to start operation. Verify input and try operation again.\nFailed to start operation. Verify input and try operation again.\nPossible Causes: \"Invalid parameters were specified.\"\nRecommended Action: \"Verify the input and try again.\"",
+		Status:       "BadRequest",
+	}
+	actual, err := parseErrorFromApiResponse(input)
+	if err != nil {
+		t.Fatalf("parsing error from api response: %+v", err)
+	}
+	if actual == nil {
+		t.Fatalf("`actual` was nil")
+	}
+	if !reflect.DeepEqual(*actual, expected) {
+		t.Fatalf("expected and actual didn't match. Expected: %+v\n\n Actual: %+v", expected, actual)
+	}
+}
+
+func TestParseErrorFromApiResponse_ResourceManagerType2Alt(t *testing.T) {
+	body := `{"error":{"code":"ValidationError","message":"The request is not valid.","details":[{"code":"InvalidDevCenterName","target":"Name","message":"Resource name is not valid. It must be between 3 and 26 characters and can only include alphanumeric characters and hyphens.","details":[],"additionalInfo":[]}]}}`
+	input := http.Response{
+		Body: io.NopCloser(bytes.NewReader([]byte(body))),
+	}
+	expected := Error{
+		ActivityId:   "",
+		Code:         "InvalidDevCenterName",
+		FullHttpBody: body,
+		Message:      "The request is not valid.\nResource name is not valid. It must be between 3 and 26 characters and can only include alphanumeric characters and hyphens.",
+		Status:       "ValidationError",
 	}
 	actual, err := parseErrorFromApiResponse(input)
 	if err != nil {


### PR DESCRIPTION
Sometimes the inner message can have more details, meaning we should surface that too. This turns:

```
ValidationError: The request is not valid
```

into:

```
The request is not valid.
Resource name is not valid. It must be between 3 and 26 characters and can only include alphanumeric characters and hyphens.
```

Spotted in DevCenter