### PR TITLE
sdk/client: auto-retrying when a 408 is returned

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -365,7 +365,7 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 				return true, nil
 			}
 
-			// Some API's don't return a response in time
+			// Some APIs don't return a response in time
 			if r.StatusCode == http.StatusRequestTimeout {
 				return true, nil
 			}

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -365,6 +365,11 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 				return true, nil
 			}
 
+			// Some API's don't return a response in time
+			if r.StatusCode == http.StatusRequestTimeout {
+				return true, nil
+			}
+
 			// Extract OData from response, intentionally ignoring any errors as it's not crucial to extract
 			// valid OData at this point (valid json can still error here, such as any non-object literal)
 			o, _ := odata.FromResponse(r)


### PR DESCRIPTION
Seen in the Dalek:

```
 2023/10/19 17:10:44 processing Resource Manager: running Subscription Cleaner "Delete Resource Groups in Subscription" in "Subscription (Subscription: \"XXX\")": running Cleaner "Notification Hub Namespaces" for Resource Group (Subscription: "1a6092a6-137e-4025-9a7c-ef77f76f2c02"
19:10:44   Resource Group Name: "acctestRG-231016095632111930"): deleting Namespace (Subscription: "XXX"
19:10:44   Resource Group Name: "acctestRG-231016095632111930"
19:10:44   Namespace Name: "acctestnhn-231016095632111930"): performing Delete: unexpected status 408 with error: RequestTimeout:
```