### PR TITLE
tooling: run labeler once per PR

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -1,6 +1,8 @@
 name: "Pull Request Labeler"
 on:
-  - pull_request_target
+  pull_request_target:
+    types:
+      - opened # run once per PR to work around https://github.com/actions/labeler/issues/624 (avoid unwanted label removal)
 
 jobs:
   triage:


### PR DESCRIPTION
to avoid removing `release-once-merged` label, works around https://github.com/actions/labeler/issues/624