### PR TITLE
Changing the cloud names to be the same as the one defined in the metadata host

### DIFF
--- a/sdk/environments/azure_china.go
+++ b/sdk/environments/azure_china.go
@@ -3,7 +3,7 @@
 
 package environments
 
-const AzureChinaCloud = "China"
+const AzureChinaCloud = "AzureChinaCloud"
 
 func AzureChina() *Environment {
 	env := baseEnvironmentWithName(AzureChinaCloud)

--- a/sdk/environments/azure_gov.go
+++ b/sdk/environments/azure_gov.go
@@ -3,7 +3,7 @@
 
 package environments
 
-const AzureUSGovernmentCloud = "USGovernment"
+const AzureUSGovernmentCloud = "AzureUSGovernment"
 
 func AzureUSGovernment() *Environment {
 	env := baseEnvironmentWithName(AzureUSGovernmentCloud)

--- a/sdk/environments/azure_public.go
+++ b/sdk/environments/azure_public.go
@@ -3,7 +3,7 @@
 
 package environments
 
-const AzurePublicCloud = "Public"
+const AzurePublicCloud = "AzureCloud"
 
 func AzurePublic() *Environment {
 	env := baseEnvironmentWithName(AzurePublicCloud)

--- a/sdk/environments/from_endpoint_test.go
+++ b/sdk/environments/from_endpoint_test.go
@@ -14,20 +14,29 @@ func TestFromEndpoint_Public(t *testing.T) {
 		t.Fatalf("loading from endpoint: %+v", err)
 	}
 
-	if actual.Name != "AzureCloud" {
-		t.Fatalf("expected the Environment name to be `AzureCloud` but got %q", actual.Name)
+	if actual.Name != AzurePublicCloud {
+		t.Fatalf("expected the Environment name to be `%s` but got %q", AzurePublicCloud, actual.Name)
 	}
 }
 
 func TestFromEndpoint_USGovernment(t *testing.T) {
-	t.Skip("Skipping because USGovernment ARM metadata service has reverted to older schema 2019-05-01 (manicminer, 2023-02-02)")
-
 	actual, err := FromEndpoint(context.Background(), "https://management.usgovcloudapi.net", "AzureUSGovernment")
 	if err != nil {
 		t.Fatalf("loading from endpoint: %+v", err)
 	}
 
-	if actual.Name != "AzureCloud" {
-		t.Fatalf("expected the Environment name to be `AzureCloud` but got %q", actual.Name)
+	if actual.Name != AzureUSGovernmentCloud {
+		t.Fatalf("expected the Environment name to be `%s` but got %q", AzureUSGovernmentCloud, actual.Name)
+	}
+}
+
+func TestFromEndpoint_China(t *testing.T) {
+	actual, err := FromEndpoint(context.Background(), "https://management.chinacloudapi.cn", "AzureUSGovernment")
+	if err != nil {
+		t.Fatalf("loading from endpoint: %+v", err)
+	}
+
+	if actual.Name != AzureChinaCloud {
+		t.Fatalf("expected the Environment name to be `%s` but got %q", AzureChinaCloud, actual.Name)
 	}
 }


### PR DESCRIPTION
This PR renames the Public/USGov/China cloud environment names to the ones defined in their respective metadata host (2022-09-01 schema).

The motivation of the renaming is that in the azurerm provider, there are if checks for the current environment name, in which case, the name will be different when directly specified, i.e. via the `environment` property (e.g. it is `public` for public cloud), or read from the metadata host (e.g. it is `AzureCloud` for public cloud).

Example code: https://github.com/hashicorp/terraform-provider-azurerm/blob/41be3be3b9621c0f40014a172a678227317950f8/internal/services/storage/storage_account_resource.go#L1150 (related issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/23764)

Meanwhile, it enables the `TestFromEndpoint_USGovernment` test case given the 2022-09-01 API version works now.

## Test

```shell
💢  go test -v ./...
=== RUN   TestIsAzureStack_BuiltInEnvironmentsShouldNotBeMarkedAsStack
2023/11/06 11:40:03 Environment: "AzureCloud"
2023/11/06 11:40:03 Environment: "Canary"
2023/11/06 11:40:03 Environment: "AzureChinaCloud"
2023/11/06 11:40:03 Environment: "AzureUSGovernment"
2023/11/06 11:40:03 Environment: "USGovernmentL5"
--- PASS: TestIsAzureStack_BuiltInEnvironmentsShouldNotBeMarkedAsStack (0.00s)
=== RUN   TestIsAzureStack
2023/11/06 11:40:03 Environment "AzureStackCloud"
2023/11/06 11:40:03 Environment "Identity Provider Empty"
2023/11/06 11:40:03 Environment "Identity Provider Custom"
2023/11/06 11:40:03 Environment "Tenant Empty"
2023/11/06 11:40:03 Environment "Tenant Custom"
--- PASS: TestIsAzureStack (0.00s)
=== RUN   TestEndpointRefresh_China
--- PASS: TestEndpointRefresh_China (0.37s)
=== RUN   TestEndpointRefresh_Public
--- PASS: TestEndpointRefresh_Public (0.57s)
=== RUN   TestEndpointRefresh_USGovernment
--- PASS: TestEndpointRefresh_USGovernment (1.63s)
=== RUN   TestFromEndpoint_Public
--- PASS: TestFromEndpoint_Public (0.51s)
=== RUN   TestFromEndpoint_USGovernment
--- PASS: TestFromEndpoint_USGovernment (1.17s)
=== RUN   TestFromEndpoint_China
--- PASS: TestFromEndpoint_China (0.09s)
=== RUN   TestFromName
    from_name_test.go:54: Printing "canary"
    from_name_test.go:54: Printing "china"
    from_name_test.go:54: Printing "dod"
    from_name_test.go:54: Printing "global"
    from_name_test.go:54: Printing "public"
    from_name_test.go:54: Printing "usgovernment"
    from_name_test.go:54: Printing "usgovernmentl4"
    from_name_test.go:54: Printing "usgovernmentl5"
    from_name_test.go:54: Printing "mars"
--- PASS: TestFromName (0.00s)
PASS
ok      github.com/hashicorp/go-azure-sdk/sdk/environments      4.356s
```