### PR TITLE
automation: conditionally pushing the branch/polling for the PR/posting a comment only when changes exist

### DIFF
--- a/.github/workflows/automation-release.yaml
+++ b/.github/workflows/automation-release.yaml
@@ -67,6 +67,11 @@ jobs:
         name: "Update then push the AzureRM Provider"
         run: |
           ./scripts/update-azurerm-provider.sh ${{ needs.release-go-sdk.outputs.latest_tag }}
+          if [[ $(git diff main --name-only | wc -l) -gt 0 ]]; then
+            echo "has_changes_to_push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes_to_push=false" >> "$GITHUB_OUTPUT"
+          fi
         shell: bash
         env:
           GIT_COMMIT_USERNAME: "hc-github-team-tf-azure"
@@ -94,7 +99,7 @@ jobs:
 
       - id: find-pr-number
         name: Find the PR number
-        if: success()
+        if: ${{ steps.update-azurerm-provider.outputs.has_changes_to_push == 'true' }}
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 20
@@ -116,7 +121,7 @@ jobs:
           GH_TOKEN: "${{ secrets.AZURERM_COMMENT_KEY }}"
 
       - name: Comment on the PR with the PR description
-        if: success()
+        if: ${{ steps.update-azurerm-provider.outputs.has_changes_to_push == 'true' }}
         run: |
           pr_number="${{ steps.find-pr-number.outputs.pr_number }}"
           echo "Commenting on PR Number ${pr_number}.."


### PR DESCRIPTION
This means we'll only attempt to push a branch/poll for the PR/post a comment when there's differences between the current branch and `main`