### PR TITLE
auth: support caching of values retrieves from Azure CLI to avoid unnecessary repeated invocations

### DIFF
--- a/sdk/auth/auth.go
+++ b/sdk/auth/auth.go
@@ -126,9 +126,10 @@ func NewAuthorizerFromCredentials(ctx context.Context, c Credentials, api enviro
 
 	if c.EnableAuthenticatingUsingAzureCLI {
 		opts := AzureCliAuthorizerOptions{
-			Api:          api,
-			TenantId:     c.TenantID,
-			AuxTenantIds: c.AuxiliaryTenantIDs,
+			Api:           api,
+			TenantId:      c.TenantID,
+			AuxTenantIds:  c.AuxiliaryTenantIDs,
+			EnableCaching: c.AzureCLIUseCache,
 		}
 		a, err := NewAzureCliAuthorizer(ctx, opts)
 		if err != nil {

--- a/sdk/auth/config.go
+++ b/sdk/auth/config.go
@@ -21,6 +21,8 @@ type Credentials struct {
 
 	// EnableAuthenticatingUsingAzureCLI specifies whether Azure CLI authentication should be checked.
 	EnableAuthenticatingUsingAzureCLI bool
+	// AzureCLIUseCache specifies whether caching should be enabled for idempotent operation results
+	AzureCLIUseCache bool
 
 	// EnableAuthenticatingUsingClientCertificate specifies whether Client Certificate authentication should be checked.
 	EnableAuthenticatingUsingClientCertificate bool

--- a/sdk/internal/azurecli/versions.go
+++ b/sdk/internal/azurecli/versions.go
@@ -3,8 +3,5 @@
 
 package azurecli
 
-const (
-	MinimumVersion   = "2.0.81"
-	MsalVersion      = "2.30.0"
-	NextMajorVersion = "3.0.0"
-)
+// MsalVersion is the first known version of Azure CLI to support MSAL / v2 tokens
+const MsalVersion = "2.30.0"


### PR DESCRIPTION
This implements caching of important primitives: `AzVersion`, `DefaultSubscriptionId`, and `DefaultTenantId`. The first time these are needed by the authorizer, they are obtained by calling az-cli, but subsequent retrievals (e.g. from additional authorizers being set up) are from a package-level cache (in the `auth` package), yielding improved performance.

**Before**

![SCR-20231128-pxw](https://github.com/hashicorp/go-azure-sdk/assets/251987/edf006bc-8e31-4ad7-be14-1b4720af2ca4)


**After**

![SCR-20231128-pt6](https://github.com/hashicorp/go-azure-sdk/assets/251987/bdd5318a-65b3-4076-adc5-3d178c883712)

I believe it's better to implement this within the authorizer, rather than at the lower-level `azurecli` internal helper package. With the latter, it'd be more robust as we could index the cache by the actual operation (caching the actual output) however that would probably need to be toggled at the package level which could lead to race conditions down the line if the `azurecli` package gets used anywhere else.

Resolves: #752
Replaces: #707
Related: https://github.com/hashicorp/terraform-provider-azurerm/issues/23977