### PR TITLE
Support subscription ids for cli authorizer

### DIFF
--- a/sdk/auth/azure_cli_authorizer_test.go
+++ b/sdk/auth/azure_cli_authorizer_test.go
@@ -80,6 +80,42 @@ func TestAccAzureCliAuthorizerWithTenant(t *testing.T) {
 	}
 }
 
+func TestAccAzureCliAuthorizerWithSubscriptions(t *testing.T) {
+	test.AccTest(t)
+
+	ctx := context.Background()
+
+	env, err := environments.FromName(test.Environment)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, subscriptionId := range test.SubscriptionIds {
+		opts := auth.AzureCliAuthorizerOptions{
+			Api:            env.MicrosoftGraph,
+			SubscriptionId: subscriptionId,
+		}
+
+		authorizer, err := auth.NewAzureCliAuthorizer(ctx, opts)
+		if err != nil {
+			t.Fatalf("NewAzureCliAuthorizer(): %v", err)
+		}
+
+		cliAuth, err := testCheckAzureCliAuthorizer(authorizer)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if cliAuth.SubscriptionId != subscriptionId {
+			t.Fatalf("cliAuth.SubscriptionId has unexpected value %q", cliAuth.SubscriptionId)
+		}
+
+		if _, err := testObtainAccessToken(ctx, authorizer); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func testCheckAzureCliAuthorizer(authorizer auth.Authorizer) (*auth.AzureCliAuthorizer, error) {
 	if authorizer == nil {
 		return nil, fmt.Errorf("authorizer is nil, expected Authorizer")

--- a/sdk/internal/test/environment_variables.go
+++ b/sdk/internal/test/environment_variables.go
@@ -11,6 +11,7 @@ import (
 var (
 	TenantId                      = os.Getenv("ARM_TENANT_ID")
 	AuxiliaryTenantIds            = strings.Split(os.Getenv("ARM_AUXILIARY_TENANT_IDS"), ";")
+	SubscriptionIds               = strings.Split(os.Getenv("ARM_SUBSCRIPTION_IDS"), ";")
 	ClientId                      = os.Getenv("ARM_CLIENT_ID")
 	ClientCertificate             = os.Getenv("ARM_CLIENT_CERTIFICATE")
 	ClientCertificatePath         = os.Getenv("ARM_CLIENT_CERTIFICATE_PATH")


### PR DESCRIPTION
This adds support for specifying an explicit subscription id for `get-access-token` call, which currently always obtains a token for the default subscription.

Required to fix subscription id regression in azurerm terraform provider, please see the link below.
https://github.com/hashicorp/terraform-provider-azurerm/issues/23068

I am not sure if this is a good implementation per se, because of how it interacts with tenants.
Azure CLI requires you to specify either a subscription id or a tenant id, but not both, so I've added two checks there.

Should this perhaps be refactored into a separate Authorizer?
One that would not accept tenant ids in its configuration and will always return an error or an empty result when asked for auxiliary ids?