### PR TITLE
environments: fix identifier URI for storage in china

### DIFF
--- a/sdk/environments/azure_china.go
+++ b/sdk/environments/azure_china.go
@@ -33,7 +33,7 @@ func AzureChina() *Environment {
 	env.Postgresql = PostgresqlAPI("postgres.database.chinacloudapi.cn").withResourceIdentifier("https://ossrdbms-aad.database.chinacloudapi.cn")
 	env.ServiceBus = ServiceBusAPI("https://servicebus.chinacloudapi.cn", "servicebus.chinacloudapi.cn")
 	env.Sql = SqlAPI("database.chinacloudapi.cn").withResourceIdentifier("https://database.chinacloudapi.cn")
-	env.Storage = StorageAPI("core.chinacloudapi.cn").withResourceIdentifier("https://core.chinacloudapi.cn")
+	env.Storage = StorageAPI("core.chinacloudapi.cn").withResourceIdentifier("https://storage.azure.com")
 	env.Synapse = SynapseAPI("dev.azuresynapse.azure.cn")
 	env.TrafficManager = TrafficManagerAPI("trafficmanager.cn")
 


### PR DESCRIPTION
Storage in china actually uses `https://storage.azure.com` as identifier URI, not `https://core.chinacloudapi.cn`

![SCR-20231214-uiq](https://github.com/hashicorp/go-azure-sdk/assets/251987/697778de-8e70-4915-9fc8-75bb08b7c4ee)

![SCR-20231214-uhn](https://github.com/hashicorp/go-azure-sdk/assets/251987/4b81db4d-28e4-45f9-880c-8898656dfdda)
