### PR TITLE
automation: outputting the value and not the key/value into the automation file

### DIFF
--- a/scripts/update-azurerm-provider.sh
+++ b/scripts/update-azurerm-provider.sh
@@ -57,7 +57,7 @@ function runUpdaterTool {
   popd
 
   echo "Writing has changes to push to file"
-  echo "has_changes_to_push=${hasChangesToPush}" > "${workingDirectory}/has-changes-to-push.txt"
+  echo "${hasChangesToPush}" > "${workingDirectory}/has-changes-to-push.txt"
 }
 
 function main {


### PR DESCRIPTION
This file is used to output the variable for whether there's changes to push or not, but since we're outputting this into a variable elsewhere, we can just output this as the value and not a key/value pair here.