### PR TITLE
automation: splitting the determining and publishing of the Git Tag

### DIFF
--- a/.github/workflows/automation-release.yaml
+++ b/.github/workflows/automation-release.yaml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
     outputs:
-      latest_tag: ${{ steps.results.outputs.latest_tag }}
+      latest_tag: ${{ steps.results.version-number.latest_tag }}
       should_update_azurerm: ${{ steps.results.outputs.should_update_azurerm }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -24,15 +24,20 @@ jobs:
           make tools
           make test
 
-      - name: "determine and publish the Git Tag"
+      - id: version-number
+        name: "Determining the Version Number.."
+          latestTag=$(./scripts/determine-git-tag.sh)
+          echo "latest_tag=$latestTag" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: "Publish the Git Tag"
         run: |
-          ./scripts/determine-and-publish-git-tag.sh
+          ./scripts/publish-git-tag.sh ${{ steps.results.version-number.latest_tag }}
+        shell: bash
 
       - id: results
         name: "collecting outputs"
         run: |
-          latestTag=$(git describe --tags $(git rev-list --tags --max-count=1))
-          echo "latest_tag=$latestTag" >> "$GITHUB_OUTPUT"
           echo "should_update_azurerm=${{ github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'update-azurerm-after-release') }}" >> "$GITHUB_OUTPUT"
         shell: bash
 

--- a/scripts/determine-git-tag.sh
+++ b/scripts/determine-git-tag.sh
@@ -23,20 +23,8 @@ function determineGitTag {
   date '+v0.%Y%m%d.1%H%M%S'
 }
 
-function publish {
-  local version=$1
-
-  echo "Tagging as '$version'.."
-  git tag "$version"
-
-  echo "Pushing Tags.."
-  git push --tags
-}
-
 function main {
-  local gitTag
-  gitTag=$(determineGitTag)
-  publish "$gitTag"
+  determineGitTag
 }
 
 main

--- a/scripts/publish-git-tag.sh
+++ b/scripts/publish-git-tag.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+function publish {
+  local version=$1
+
+  echo "Tagging as '$version'.."
+  git tag "$version"
+
+  echo "Pushing Tags.."
+  git push --tags
+}
+
+function main {
+  local version=$1
+
+  publish "$version"
+}
+
+main "$1"


### PR DESCRIPTION
This is needed as a part of https://github.com/hashicorp/pandora/issues/3601 since we're going to be publishing multiple Go Modules at different paths - but the version number of each of them is going to be the same.

As such this PR splits the determining and publishing of the Git Tag - such that the existing update tooling continues to work with minor changes (tracked in https://github.com/hashicorp/terraform-provider-azurerm/pull/24602).

Given this is a Github Action this is hard to test locally - I've tested the scripts (which are fine) - but I suspect this change should be fine to merge today, prior to enabling module support.