### PR TITLE
automation: updating the go module update to use sed

### DIFF
--- a/.github/workflows/automation-release.yaml
+++ b/.github/workflows/automation-release.yaml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: ./.go-version
+
       - name: run the unit tests
         run: |
           make tools

--- a/scripts/publish-git-tag.sh
+++ b/scripts/publish-git-tag.sh
@@ -26,7 +26,12 @@ function updateSdkReferenceAndCommitChanges {
   cd "${directory}"
 
   echo "Updating the dependency on 'github.com/hashicorp/go-azure-sdk/sdk'.."
-  sed -i "s/github.com\/hashicorp\/go-azure-sdk\/sdk.*/github.com\/hashicorp\/go-azure-sdk\/sdk $tag/g" go.mod
+  if [[ $(uname) == "Darwin" ]]; then
+    echo "Using BSD sed"
+    sed -i "" "s/github.com\/hashicorp\/go-azure-sdk\/sdk.*/github.com\/hashicorp\/go-azure-sdk\/sdk $tag/g" go.mod
+  else
+    sed -i "s/github.com\/hashicorp\/go-azure-sdk\/sdk.*/github.com\/hashicorp\/go-azure-sdk\/sdk $tag/g" go.mod
+  fi
 
   echo "Running 'go mod tidy'.."
   go mod tidy

--- a/scripts/publish-git-tag.sh
+++ b/scripts/publish-git-tag.sh
@@ -26,7 +26,7 @@ function updateSdkReferenceAndCommitChanges {
   cd "${directory}"
 
   echo "Updating the dependency on 'github.com/hashicorp/go-azure-sdk/sdk'.."
-  go get "github.com/hashicorp/go-azure-sdk/sdk@$tag"
+  sed -i "s/github.com\/hashicorp\/go-azure-sdk\/sdk.*/github.com\/hashicorp\/go-azure-sdk\/sdk $tag/g" go.mod
 
   echo "Running 'go mod tidy'.."
   go mod tidy


### PR DESCRIPTION
Using `go get` on the SDK module means that we can end up unintentionally downgrading, since we're sure the SDK Version
exists (since we've just published it) - `sed` ensures this value will be what we're expecting.