### PR TITLE
tooling: updating the labeller to add `release-once-merged` for both `microsoft-graph` and `sdk`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,4 +4,6 @@
 release-once-merged:
 - changed-files:
   - any-glob-to-any-file:
+    - microsoft-graph/**/*
     - resource-manager/**/*
+    - sdk/**/*


### PR DESCRIPTION
Minor nit, but ensures that `release-once-merged` is added for all the Auto PRs