### PR TITLE
poller: add `Created `as inprogress status for fabric managed

### DIFF
--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -174,6 +174,8 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			"CancelInProgress": pollers.PollingStatusInProgress,
 			// CostManagement@2021-10-01 returns `Completed` rather than `Succeeded`: https://github.com/Azure/azure-sdk-for-go/issues/20342
 			"Completed": pollers.PollingStatusSucceeded,
+			// ServiceFabricManaged @ 2021-05-01 (NodeTypes CreateOrUpdate) returns `Created` rather than `InProgress` during Creation
+			"Created": pollers.PollingStatusInProgress,
 			// ContainerRegistry@2019-06-01-preview returns `Creating` rather than `InProgress` during creation
 			"Creating": pollers.PollingStatusInProgress,
 			// SignalR@2022-02-01 returns `Running` rather than `InProgress` during creation
@@ -203,8 +205,6 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			"Scaling": pollers.PollingStatusInProgress,
 			// HealthBot @ 2022-08-08 (HealthBots CreateOrUpdate) returns `Working` during Creation
 			"Working": pollers.PollingStatusInProgress,
-			// ServiceFabricManaged @ 2021-05-01 (NodeTypes CreateOrUpdate) returns `Created` rather than `InProgress` during Creation
-			"Created": pollers.PollingStatusInProgress,
 		}
 		for k, v := range statuses {
 			if strings.EqualFold(string(op.Properties.ProvisioningState), string(k)) {

--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -203,6 +203,8 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			"Scaling": pollers.PollingStatusInProgress,
 			// HealthBot @ 2022-08-08 (HealthBots CreateOrUpdate) returns `Working` during Creation
 			"Working": pollers.PollingStatusInProgress,
+			// ServiceFabricManaged @ 2021-05-01 (NodeTypes CreateOrUpdate) returns `Created` rather than `InProgress` during Creation
+			"Created": pollers.PollingStatusInProgress,
 		}
 		for k, v := range statuses {
 			if strings.EqualFold(string(op.Properties.ProvisioningState), string(k)) {


### PR DESCRIPTION
This PR is to fix the issue caused by upgrading fabric managed service sdk to new base layer: https://github.com/hashicorp/terraform-provider-azurerm/pull/24654#issuecomment-1918502177. 

Acctest failure message:

```
    testcase.go:113: Step 5/5 error: Error running apply: exit status 1
        Error: adding/updating Node Type (Subscription: "*******"
        Resource Group Name: "acctestRG-sfmc-240131010138563091"
        Managed Cluster Name: "testacc-sfmc-xyszh"
        Node Type Name: "test1"): polling after CreateOrUpdate: `result.Status` was nil/empty - `op.Status` was "Created" / `op.Properties.ProvisioningState` was ""
          with azurerm_service_fabric_managed_cluster.test,
          on terraform_plugin_test.tf line 26, in resource "azurerm_service_fabric_managed_cluster" "test":
          26: resource "azurerm_service_fabric_managed_cluster" "test" {
        adding/updating Node Type (Subscription:
        "*******"
        Resource Group Name: "acctestRG-sfmc-240131010138563091"
        Managed Cluster Name: "testacc-sfmc-xyszh"
        Node Type Name: "test1"): polling after CreateOrUpdate: `result.Status` was
        nil/empty - `op.Status` was "Created" / `op.Properties.ProvisioningState` was
        ""
--- FAIL: TestAccServiceFabricManagedCluster_full (4313.13s)
```

Local test passed:
```
=== RUN   TestAccServiceFabricManagedCluster_full
=== PAUSE TestAccServiceFabricManagedCluster_full
=== CONT  TestAccServiceFabricManagedCluster_full
--- PASS: TestAccServiceFabricManagedCluster_full (4478.90s)
PASS
```
