### PR TITLE
sdk: check for empty response body before unmarshalling

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -189,6 +189,11 @@ func (r *Response) Unmarshal(model interface{}) error {
 		// Trim away a BOM if present
 		respBody = bytes.TrimPrefix(respBody, []byte("\xef\xbb\xbf"))
 
+		// In some cases the respBody is empty, but not nil, so don't attempt to unmarshal this
+		if len(respBody) == 0 {
+			return nil
+		}
+
 		// Unmarshal into provided model
 		if err := json.Unmarshal(respBody, model); err != nil {
 			return fmt.Errorf("unmarshaling response body: %+v", err)

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -215,6 +215,11 @@ func (r *Response) Unmarshal(model interface{}) error {
 		// Trim away a BOM if present
 		respBody = bytes.TrimPrefix(respBody, []byte("\xef\xbb\xbf"))
 
+		// In some cases the respBody is empty, but not nil, so don't attempt to unmarshal this
+		if len(respBody) == 0 {
+			return nil
+		}
+
 		// Unmarshal into provided model
 		if err := xml.Unmarshal(respBody, model); err != nil {
 			return err


### PR DESCRIPTION
Fixes a bug with Maintenance Delete where the response body is empty, but not nil, so this does not get unmarshalled.