### PR TITLE
Odata: enhance nextLink unmarshal

### DIFF
--- a/sdk/odata/odata.go
+++ b/sdk/odata/odata.go
@@ -93,14 +93,14 @@ type OData struct {
 	MetadataEtag *string `json:"@odata.metadataEtag"`
 	Type         *Type   `json:"@odata.type"`
 	Count        *int    `json:"@odata.count"`
-	NextLink     *Link   `json:"@odata.nextLink"`
 	Delta        *string `json:"@odata.delta"`
 	DeltaLink    *Link   `json:"@odata.deltaLink"`
 	Id           *Id     `json:"@odata.id"`
 	EditLink     *Link   `json:"@odata.editLink"`
 	Etag         *string `json:"@odata.etag"`
 
-	Error *Error `json:"-"`
+	Error    *Error `json:"-"`
+	NextLink *Link  `json:"-"`
 
 	Value interface{} `json:"value"`
 }
@@ -127,6 +127,18 @@ func (o *OData) UnmarshalJSON(data []byte) error {
 				return err
 			}
 			o.Error = &e2
+			break
+		}
+	}
+
+	for _, k := range []string{"nextLink", "@odata.nextlink"} {
+		if v, ok := e[k]; ok {
+			var l2 Link
+			if err := json.Unmarshal(v, &l2); err != nil {
+				return err
+			}
+
+			o.NextLink = &l2
 			break
 		}
 	}


### PR DESCRIPTION
try to resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/24948

Seems the error is because code-gen does not handle [`x-ms-pageable.nextLinkName`](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/creating-swagger.md#paging-with-x-ms-pageable)

And the `nextLink` is used in https://github.com/hashicorp/go-azure-sdk/blob/8ee56b008ba9275ff6c3282052e6b50e83073f9a/sdk/client/client.go#L538-L579

This PR simply hardcode the `nextLink` to handle the case pageable List API returns next link through `nextLink` field instead of standard `@odata.nextLink` field. 

A more robust solution is to make use of [`x-ms-pageable.nextLinkName`](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/creating-swagger.md#paging-with-x-ms-pageable) for pageable List API at the [generator-go-sdk](https://github.com/hashicorp/pandora/blob/368ec110f6eb14be8bea9a55357770b797739cb5/tools/generator-go-sdk/internal/generator/templater_methods.go#L312) , but it might break existing code struct.