### PR TITLE
enhancement: include HTTP status text in error when response is unexpected

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -513,10 +513,21 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 
 	// Determine whether response status is valid
 	if !containsStatusCode(req.ValidStatusCodes, resp.StatusCode) {
-		// The status code didn't match, but we also need to check the ValidStatusFUnc, if provided
+		// The status code didn't match, but we also need to check the ValidStatusFunc, if provided
 		// Note that the odata argument here is a best-effort and may be nil
 		if f := req.ValidStatusFunc; f != nil && f(resp.Response, resp.OData) {
 			return resp, nil
+		}
+
+		status := fmt.Sprintf("%d", resp.StatusCode)
+
+		// Prefer the status text returned in the response, but fall back to predefined status if absent
+		statusText := resp.Status
+		if statusText == "" {
+			statusText = http.StatusText(resp.StatusCode)
+		}
+		if statusText != "" {
+			status = fmt.Sprintf("%s (%s)", status, statusText)
 		}
 
 		// Determine suitable error text
@@ -530,16 +541,16 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 
 			respBody, err := io.ReadAll(resp.Body)
 			if err != nil {
-				return resp, fmt.Errorf("unexpected status %d, could not read response body", resp.StatusCode)
+				return resp, fmt.Errorf("unexpected status %s, could not read response body", status)
 			}
 			if len(respBody) == 0 {
-				return resp, fmt.Errorf("unexpected status %d received with no body", resp.StatusCode)
+				return resp, fmt.Errorf("unexpected status %s received with no body", status)
 			}
 
 			errText = fmt.Sprintf("response: %s", respBody)
 		}
 
-		return resp, fmt.Errorf("unexpected status %d with %s", resp.StatusCode, errText)
+		return resp, fmt.Errorf("unexpected status %s with %s", status, errText)
 	}
 
 	return resp, nil


### PR DESCRIPTION
Minor improvement, but adds a small amount of context mainly useful in the case that the API returns no error text.