### PR TITLE
auth: support subscription hint for Azure CLI, to help with multiple signed-in accounts with segregated access

### DIFF
--- a/sdk/auth/auth.go
+++ b/sdk/auth/auth.go
@@ -126,9 +126,10 @@ func NewAuthorizerFromCredentials(ctx context.Context, c Credentials, api enviro
 
 	if c.EnableAuthenticatingUsingAzureCLI {
 		opts := AzureCliAuthorizerOptions{
-			Api:          api,
-			TenantId:     c.TenantID,
-			AuxTenantIds: c.AuxiliaryTenantIDs,
+			Api:                api,
+			TenantId:           c.TenantID,
+			AuxTenantIds:       c.AuxiliaryTenantIDs,
+			SubscriptionIdHint: c.AzureCliSubscriptionIDHint,
 		}
 		a, err := NewAzureCliAuthorizer(ctx, opts)
 		if err != nil {

--- a/sdk/auth/auth_test.go
+++ b/sdk/auth/auth_test.go
@@ -183,6 +183,7 @@ func TestAccNewAuthorizerFromCredentials(t *testing.T) {
 
 	credentials := auth.Credentials{
 		AuxiliaryTenantIDs:            test.AuxiliaryTenantIds,
+		AzureCliSubscriptionIDHint:    test.SubscriptionId,
 		ClientCertificateData:         test.Base64DecodeCertificate(t, test.ClientCertificate),
 		ClientCertificatePassword:     test.ClientCertPassword,
 		ClientCertificatePath:         test.ClientCertificatePath,

--- a/sdk/auth/auth_test.go
+++ b/sdk/auth/auth_test.go
@@ -183,7 +183,6 @@ func TestAccNewAuthorizerFromCredentials(t *testing.T) {
 
 	credentials := auth.Credentials{
 		AuxiliaryTenantIDs:            test.AuxiliaryTenantIds,
-		AzureCliSubscriptionIDHint:    test.SubscriptionId,
 		ClientCertificateData:         test.Base64DecodeCertificate(t, test.ClientCertificate),
 		ClientCertificatePassword:     test.ClientCertPassword,
 		ClientCertificatePath:         test.ClientCertificatePath,
@@ -206,6 +205,7 @@ func TestAccNewAuthorizerFromCredentials(t *testing.T) {
 			credentials: func() (ret auth.Credentials) {
 				ret = credentials
 				ret.EnableAuthenticatingUsingAzureCLI = true
+				ret.AzureCliSubscriptionIDHint = test.SubscriptionId
 				return
 			},
 			check: func(a auth.Authorizer) error {

--- a/sdk/auth/azure_cli_authorizer.go
+++ b/sdk/auth/azure_cli_authorizer.go
@@ -27,11 +27,15 @@ type AzureCliAuthorizerOptions struct {
 	// used for Resource Manager when auxiliary tenants are needed.
 	// e.g. https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/authenticate-multi-tenant
 	AuxTenantIds []string
+
+	// SubscriptionIdHint is the subscription to target when selecting an account with which to obtain an access token
+	// Used to hint to Azure CLI which of its signed-in accounts it should select, based on access to the subscription.
+	SubscriptionIdHint string
 }
 
 // NewAzureCliAuthorizer returns an Authorizer which authenticates using the Azure CLI.
 func NewAzureCliAuthorizer(ctx context.Context, options AzureCliAuthorizerOptions) (Authorizer, error) {
-	conf, err := newAzureCliConfig(options.Api, options.TenantId, options.AuxTenantIds)
+	conf, err := newAzureCliConfig(options.Api, options.TenantId, options.AuxTenantIds, options.SubscriptionIdHint)
 	if err != nil {
 		return nil, err
 	}
@@ -47,6 +51,9 @@ type AzureCliAuthorizer struct {
 
 	// DefaultSubscriptionID is the default subscription, when detected
 	DefaultSubscriptionID string
+
+	// SubscriptionIDHint is a user-provided subscription ID used to hint to Azure CLI which account to select
+	SubscriptionIDHint string
 
 	conf *azureCliConfig
 }
@@ -84,6 +91,15 @@ func (a *AzureCliAuthorizer) Token(_ context.Context, _ *http.Request) (*oauth2.
 
 	// Try to detect whether authenticated principal is a managed identity
 	if accountType != nil && accountName != nil && *accountType == "servicePrincipal" && (*accountName == "systemAssignedIdentity" || *accountName == "userAssignedIdentity") {
+		tenantIdRequired = false
+	}
+
+	// Prefer to specify subscription ID if provided, this hints to Azure CLI which account to use in the event
+	// that multiple accounts are signed in, and each account has access to a subset of all subscriptions.
+	if a.SubscriptionIDHint != "" {
+		azArgs = append(azArgs, "--subscription", a.conf.SubscriptionIDHint)
+
+		// Cannot specify both `--subscription` and `--tenant`
 		tenantIdRequired = false
 	}
 
@@ -164,10 +180,13 @@ type azureCliConfig struct {
 
 	// DefaultSubscriptionID is the optional default subscription ID
 	DefaultSubscriptionID string
+
+	// SubscriptionIDHint is the subscription being targeted when obtaining a token, used to hint to Azure CLI which account to use
+	SubscriptionIDHint string
 }
 
 // newAzureCliConfig validates the supplied tenant ID and returns a new azureCliConfig.
-func newAzureCliConfig(api environments.Api, tenantId string, auxiliaryTenantIds []string) (*azureCliConfig, error) {
+func newAzureCliConfig(api environments.Api, tenantId string, auxiliaryTenantIds []string, subscriptionIdHint string) (*azureCliConfig, error) {
 	// check az-cli version, ensure that MSAL is supported
 	if err := azurecli.CheckAzVersion(); err != nil {
 		return nil, err
@@ -199,11 +218,34 @@ func newAzureCliConfig(api environments.Api, tenantId string, auxiliaryTenantIds
 		subscriptionId = *defaultSubscriptionId
 	}
 
+	// validate subscriptionIdHint, if applicable (currently only for Resource Manager)
+	if environments.ApiIsKnown(api, "AzureResourceManager") {
+		if subscriptionIdHint != "" {
+			if availableSubscriptionIds, err := azurecli.ListAvailableSubscriptionIDs(); err != nil {
+				return nil, err
+			} else if availableSubscriptionIds == nil {
+				return nil, fmt.Errorf("no available subscription IDs returned by Azure CLI")
+			} else {
+				found := false
+				for _, subId := range *availableSubscriptionIds {
+					if strings.EqualFold(subId, subscriptionIdHint) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return nil, fmt.Errorf("the provided subscription ID %q is not known by Azure CLI", subscriptionIdHint)
+				}
+			}
+		}
+	}
+
 	return &azureCliConfig{
 		Api:                   api,
 		TenantID:              tenantId,
 		AuxiliaryTenantIDs:    auxiliaryTenantIds,
 		DefaultSubscriptionID: subscriptionId,
+		SubscriptionIDHint:    strings.ToLower(subscriptionIdHint),
 	}, nil
 }
 
@@ -213,6 +255,7 @@ func (c *azureCliConfig) TokenSource(ctx context.Context) (Authorizer, error) {
 	return NewCachedAuthorizer(&AzureCliAuthorizer{
 		TenantID:              c.TenantID,
 		DefaultSubscriptionID: c.DefaultSubscriptionID,
+		SubscriptionIDHint:    c.SubscriptionIDHint,
 		conf:                  c,
 	})
 }

--- a/sdk/auth/azure_cli_authorizer.go
+++ b/sdk/auth/azure_cli_authorizer.go
@@ -29,7 +29,7 @@ type AzureCliAuthorizerOptions struct {
 	AuxTenantIds []string
 
 	// SubscriptionIdHint is the subscription to target when selecting an account with which to obtain an access token
-	// Used to hint to Azure CLI which of its signed-in accounts it should select, based on access to the subscription.
+	// Used to hint to Azure CLI which of its signed-in accounts it should select, based on apparent access to the subscription.
 	SubscriptionIdHint string
 }
 
@@ -219,7 +219,7 @@ func newAzureCliConfig(api environments.Api, tenantId string, auxiliaryTenantIds
 	}
 
 	// validate subscriptionIdHint, if applicable (currently only for Resource Manager)
-	if environments.ApiIsKnown(api, "AzureResourceManager") {
+	if environments.ApiIsKnownPublished(api, "AzureResourceManager") {
 		if subscriptionIdHint != "" {
 			if availableSubscriptionIds, err := azurecli.ListAvailableSubscriptionIDs(); err != nil {
 				return nil, err

--- a/sdk/auth/azure_cli_authorizer_test.go
+++ b/sdk/auth/azure_cli_authorizer_test.go
@@ -46,6 +46,40 @@ func TestAccAzureCliAuthorizer(t *testing.T) {
 	}
 }
 
+func TestAccAzureCliAuthorizerWithSubscription(t *testing.T) {
+	test.AccTest(t)
+
+	ctx := context.Background()
+
+	env, err := environments.FromName(test.Environment)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := auth.AzureCliAuthorizerOptions{
+		Api:                env.ResourceManager,
+		SubscriptionIdHint: test.SubscriptionId,
+	}
+
+	authorizer, err := auth.NewAzureCliAuthorizer(ctx, opts)
+	if err != nil {
+		t.Fatalf("NewAzureCliAuthorizer(): %v", err)
+	}
+
+	cliAuth, err := testCheckAzureCliAuthorizer(authorizer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cliAuth.SubscriptionIDHint != test.SubscriptionId {
+		t.Fatalf("cliAuth.SubscriptionIDHint has unexpected value %q", cliAuth.SubscriptionIDHint)
+	}
+
+	if _, err = testObtainAccessToken(ctx, authorizer); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestAccAzureCliAuthorizerWithTenant(t *testing.T) {
 	test.AccTest(t)
 

--- a/sdk/auth/config.go
+++ b/sdk/auth/config.go
@@ -21,7 +21,9 @@ type Credentials struct {
 
 	// EnableAuthenticatingUsingAzureCLI specifies whether Azure CLI authentication should be checked.
 	EnableAuthenticatingUsingAzureCLI bool
-	AzureCliSubscriptionIDHint        string
+	// AzureCliSubscriptionIDHint is the subscription to target when selecting an account with which to obtain an access token
+	// Used to hint to Azure CLI which of its signed-in accounts it should select, based on apparent access to the subscription.
+	AzureCliSubscriptionIDHint string
 
 	// EnableAuthenticatingUsingClientCertificate specifies whether Client Certificate authentication should be checked.
 	EnableAuthenticatingUsingClientCertificate bool

--- a/sdk/auth/config.go
+++ b/sdk/auth/config.go
@@ -21,6 +21,7 @@ type Credentials struct {
 
 	// EnableAuthenticatingUsingAzureCLI specifies whether Azure CLI authentication should be checked.
 	EnableAuthenticatingUsingAzureCLI bool
+	AzureCliSubscriptionIDHint        string
 
 	// EnableAuthenticatingUsingClientCertificate specifies whether Client Certificate authentication should be checked.
 	EnableAuthenticatingUsingClientCertificate bool

--- a/sdk/environments/interfaces.go
+++ b/sdk/environments/interfaces.go
@@ -31,16 +31,17 @@ type Api interface {
 	WithResourceIdentifier(string) Api
 }
 
-func ApiIsKnown(api Api, apiName string) bool {
+// ApiIsKnownPublished determines whether the provided Api represents the specified known API as published in PublishedApis
+func ApiIsKnownPublished(api Api, apiName string) bool {
 	appId, ok := api.AppId()
 	if !ok || appId == nil {
 		return false
 	}
-	resourceManagerAppId, ok := PublishedApis[apiName]
+	knownApiAppId, ok := PublishedApis[apiName]
 	if !ok {
 		return false
 	}
-	if !strings.EqualFold(*appId, resourceManagerAppId) {
+	if !strings.EqualFold(*appId, knownApiAppId) {
 		return false
 	}
 	return true

--- a/sdk/environments/interfaces.go
+++ b/sdk/environments/interfaces.go
@@ -3,6 +3,10 @@
 
 package environments
 
+import (
+	"strings"
+)
+
 type Api interface {
 	// AppId is a GUID that identifies the application/API in the cloud environment
 	AppId() (*string, bool)
@@ -25,4 +29,19 @@ type Api interface {
 
 	// WithResourceIdentifier overrides the default resource ID for the API and is useful for APIs that offer multiple authorization scopes
 	WithResourceIdentifier(string) Api
+}
+
+func ApiIsKnown(api Api, apiName string) bool {
+	appId, ok := api.AppId()
+	if !ok || appId == nil {
+		return false
+	}
+	resourceManagerAppId, ok := PublishedApis[apiName]
+	if !ok {
+		return false
+	}
+	if !strings.EqualFold(*appId, resourceManagerAppId) {
+		return false
+	}
+	return true
 }

--- a/sdk/internal/azurecli/azcli.go
+++ b/sdk/internal/azurecli/azcli.go
@@ -103,6 +103,23 @@ func GetDefaultSubscriptionID() (*string, error) {
 	return account.Id, nil
 }
 
+// ListAvailableSubscriptionIDs lists the available subscriptions
+func ListAvailableSubscriptionIDs() (*[]string, error) {
+	accounts, err := listAzAccounts()
+	if err != nil {
+		return nil, fmt.Errorf("obtaining subscription ID: %s", err)
+	}
+	subscriptionIds := make([]string, 0)
+	if accounts != nil {
+		for _, account := range *accounts {
+			if account.Id != nil {
+				subscriptionIds = append(subscriptionIds, *account.Id)
+			}
+		}
+	}
+	return &subscriptionIds, nil
+}
+
 // GetAccountName returns the name of the authenticated principal
 func GetAccountName() (*string, error) {
 	account, err := getAzAccount()
@@ -131,6 +148,15 @@ func GetAccountType() (*string, error) {
 func getAzAccount() (*azAccount, error) {
 	var account azAccount
 	if err := JSONUnmarshalAzCmd(true, &account, "account", "show"); err != nil {
+		return nil, fmt.Errorf("obtaining account details: %s", err)
+	}
+	return &account, nil
+}
+
+// listAzAccounts returns the output of `az account list`
+func listAzAccounts() (*[]azAccount, error) {
+	var account []azAccount
+	if err := JSONUnmarshalAzCmd(true, &account, "account", "list"); err != nil {
 		return nil, fmt.Errorf("obtaining account details: %s", err)
 	}
 	return &account, nil

--- a/sdk/internal/test/environment_variables.go
+++ b/sdk/internal/test/environment_variables.go
@@ -9,18 +9,19 @@ import (
 )
 
 var (
-	TenantId                      = os.Getenv("ARM_TENANT_ID")
 	AuxiliaryTenantIds            = strings.Split(os.Getenv("ARM_AUXILIARY_TENANT_IDS"), ";")
-	ClientId                      = os.Getenv("ARM_CLIENT_ID")
+	ClientCertPassword            = os.Getenv("ARM_CLIENT_CERTIFICATE_PASSWORD")
 	ClientCertificate             = os.Getenv("ARM_CLIENT_CERTIFICATE")
 	ClientCertificatePath         = os.Getenv("ARM_CLIENT_CERTIFICATE_PATH")
-	ClientCertPassword            = os.Getenv("ARM_CLIENT_CERTIFICATE_PASSWORD")
+	ClientId                      = os.Getenv("ARM_CLIENT_ID")
 	ClientSecret                  = os.Getenv("ARM_CLIENT_SECRET")
-	Environment                   = envDefault("ARM_ENVIRONMENT", "global")
-	GitHubTokenURL                = os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
-	GitHubToken                   = os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
-	IdToken                       = os.Getenv("ARM_OIDC_TOKEN")
 	CustomManagedIdentityEndpoint = os.Getenv("ARM_MSI_ENDPOINT")
+	Environment                   = envDefault("ARM_ENVIRONMENT", "global")
+	GitHubToken                   = os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+	GitHubTokenURL                = os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
+	IdToken                       = os.Getenv("ARM_OIDC_TOKEN")
+	SubscriptionId                = os.Getenv("ARM_SUBSCRIPTION_ID")
+	TenantId                      = os.Getenv("ARM_TENANT_ID")
 )
 
 func envDefault(key, def string) (ret string) {


### PR DESCRIPTION
Enables Azure CLI authentication to work in the case that multiple accounts are signed in, and each account has access to a subset of the available subscriptions. Currently, we pass the tenant ID to authenticate against which leaves Azure CLI with a decision to make as for which account to obtain an access token. Usually it will look at the default account (via `az account set`) and if this matches the tenant, it'll use that. If it doesn't match, it's forced to pick one of the accounts to use. Either of these choices may not align with the Terraform config, especially if it contains aliased providers using different subscriptions.

By passing the subscription ID, we inform it (when the API being authorized is Resource Manager) of the subscription we're going to be using, so it can make a better judgement about the account to select based on the subscription(s) that account has permissions for. This may fall down if one account has more limited permissions for a given subscription than another account, but that is left to the user to assign appropriate roles as needed.

Related: https://github.com/hashicorp/terraform-provider-azurerm/issues/23068