### PR TITLE
`sdk/client/resourcemanager`: updating the `LRO` poller to treat a 404 as `InProgress` / tests covering the `LRO`/`ProvisioningState` polling scenarios

### DIFF
--- a/sdk/client/resourcemanager/poller_helpers_test.go
+++ b/sdk/client/resourcemanager/poller_helpers_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcemanager
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+)
+
+type expectedResponse struct {
+	dropsConnection      bool
+	httpStatusCode       *int
+	status               *status
+	useStatus            bool
+	useProvisioningState bool
+}
+
+func responseThatDropsTheConnection() expectedResponse {
+	return expectedResponse{
+		dropsConnection: true,
+	}
+}
+
+func responseWithStatusInProvisioningState(input status) expectedResponse {
+	return expectedResponse{
+		status:               pointer.To(input),
+		useProvisioningState: true,
+	}
+}
+
+func responseWithStatusInStatusField(input status) expectedResponse {
+	return expectedResponse{
+		status:    pointer.To(input),
+		useStatus: true,
+	}
+}
+
+func responseWithHttpStatusCode(input int) expectedResponse {
+	return expectedResponse{
+		httpStatusCode: pointer.To(input),
+	}
+}
+
+func dropConnection(t *testing.T, w http.ResponseWriter) {
+	httpHijacker, ok := w.(http.Hijacker)
+	if !ok {
+		t.Fatalf("`w` didn't implement `http.httpHijacker`")
+	}
+	conn, _, err := httpHijacker.Hijack()
+	if err != nil {
+		return
+	}
+	conn.Close()
+}

--- a/sdk/client/resourcemanager/poller_lro_helpers_test.go
+++ b/sdk/client/resourcemanager/poller_lro_helpers_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+)
+
+// longRunningOperationsEndpoint is a test helper struct which makes testing the expected behaviour of the
+// long-running operations endpoint easier. Originally these started out as a function per test, but with
+// so much boilerplate, this helped make the tests more readable, so whilst this has some boilerplate I
+// suspect it's worth it for the tradeoff of having tests that are more understandable.
+type longRunningOperationsEndpoint struct {
+	numberOfTimesCalled  int
+	responses            []longRunningOperationsExpectedResponse
+	useProvisioningState bool
+}
+
+type longRunningOperationsExpectedResponse struct {
+	status         *status
+	httpStatusCode *int
+}
+
+func responseWithStatus(input status) longRunningOperationsExpectedResponse {
+	return longRunningOperationsExpectedResponse{
+		status: pointer.To(input),
+	}
+}
+
+func responseWithHttpStatusCode(input int) longRunningOperationsExpectedResponse {
+	return longRunningOperationsExpectedResponse{
+		httpStatusCode: pointer.To(input),
+	}
+}
+
+func newLongRunningOperationsEndpoint(useProvisioningState bool, responses []longRunningOperationsExpectedResponse) longRunningOperationsEndpoint {
+	return longRunningOperationsEndpoint{
+		useProvisioningState: useProvisioningState,
+		numberOfTimesCalled:  0,
+		responses:            responses,
+	}
+}
+
+func (e *longRunningOperationsEndpoint) endpoint(t *testing.T) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("Server request %q %q", r.Method, r.RequestURI)
+
+		if r.Method != http.MethodGet && r.RequestURI != "/lro/poll" {
+			w.WriteHeader(http.StatusNotImplemented)
+			return
+		}
+
+		e.numberOfTimesCalled++
+		if e.numberOfTimesCalled > len(e.responses) {
+			t.Fatal("called too many times")
+		}
+		response := e.responses[e.numberOfTimesCalled-1]
+		if response.httpStatusCode != nil {
+			w.WriteHeader(*response.httpStatusCode)
+			return
+		}
+
+		if response.status == nil {
+			t.Fatalf("missing either a httpStatusCode or a status to return")
+		}
+		payload := operationResult{
+			Properties: operationResultProperties{
+				ProvisioningState: "",
+			},
+			Status: "",
+		}
+		if e.useProvisioningState {
+			payload.Properties.ProvisioningState = *response.status
+		} else {
+			payload.Status = *response.status
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Fatalf(err.Error())
+			return
+		}
+	}
+}
+
+func (e longRunningOperationsEndpoint) assertCalled(t *testing.T, expected int) {
+	if e.numberOfTimesCalled != expected {
+		t.Fatalf("expected to be called %d times but got %d", expected, e.numberOfTimesCalled)
+	}
+}
+
+func (e longRunningOperationsEndpoint) response() *http.Response {
+	return &http.Response{
+		Header: map[string][]string{
+			http.CanonicalHeaderKey("Azure-AsyncOperation"): {"http://localhost/lro/poll"},
+			http.CanonicalHeaderKey("Retry-After"):          {"1"},
+		},
+	}
+}

--- a/sdk/client/resourcemanager/poller_lro_test.go
+++ b/sdk/client/resourcemanager/poller_lro_test.go
@@ -1,0 +1,471 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+func TestPollerLRO_InProvisioningState_TerminalStates(t *testing.T) {
+	// This test ensures that each of the Custom Statuses works in the provisioningState field
+	ctx := context.TODO()
+	for state, expected := range longRunningOperationCustomStatuses {
+		t.Run(fmt.Sprintf("%s/%s", string(state), string(expected)), func(t *testing.T) {
+			helpers := newLongRunningOperationsEndpoint(true, []longRunningOperationsExpectedResponse{
+				responseWithStatus(state),
+			})
+			server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+			defer server.Close()
+
+			response := &client.Response{
+				Response: helpers.response(),
+			}
+			client := client.NewClient(server.URL, "MyService", "2020-02-01")
+			poller, err := longRunningOperationPollerFromResponse(response, client)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			t.Logf("Polling..")
+			result, err := poller.Poll(ctx)
+			if err != nil {
+				if expected == pollers.PollingStatusCancelled || expected == pollers.PollingStatusFailed {
+					return
+				}
+
+				t.Fatal(err.Error())
+			}
+			if result.Status != expected {
+				t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+			}
+			// sanity-checking
+			helpers.assertCalled(t, 1)
+		})
+	}
+}
+
+func TestPollerLRO_InStatus_TerminalStates(t *testing.T) {
+	// This test ensures that each of the Custom Statuses works in the status field
+	ctx := context.TODO()
+	for state, expected := range longRunningOperationCustomStatuses {
+		t.Run(fmt.Sprintf("%s/%s", string(state), string(expected)), func(t *testing.T) {
+			helpers := newLongRunningOperationsEndpoint(false, []longRunningOperationsExpectedResponse{
+				responseWithStatus(state),
+			})
+			server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+			defer server.Close()
+
+			response := &client.Response{
+				Response: helpers.response(),
+			}
+			client := client.NewClient(server.URL, "MyService", "2020-02-01")
+			poller, err := longRunningOperationPollerFromResponse(response, client)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			t.Logf("Polling..")
+			result, err := poller.Poll(ctx)
+			if err != nil {
+				if expected == pollers.PollingStatusCancelled || expected == pollers.PollingStatusFailed {
+					return
+				}
+
+				t.Fatal(err.Error())
+			}
+			if result.Status != expected {
+				t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+			}
+			// sanity-checking
+			helpers.assertCalled(t, 1)
+		})
+	}
+}
+
+func TestPollerLRO_InProvisioningState_ImmediateSuccess(t *testing.T) {
+	ctx := context.TODO()
+	helpers := newLongRunningOperationsEndpoint(true, []longRunningOperationsExpectedResponse{
+		responseWithStatus(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+	defer server.Close()
+
+	response := &client.Response{
+		Response: helpers.response(),
+	}
+	client := client.NewClient(server.URL, "MyService", "2020-02-01")
+	poller, err := longRunningOperationPollerFromResponse(response, client)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	t.Logf("Polling..")
+	result, err := poller.Poll(ctx)
+	if err != nil {
+		if result.Status == pollers.PollingStatusCancelled || result.Status == pollers.PollingStatusFailed {
+			return
+		}
+
+		t.Fatal(err.Error())
+	}
+	if result.Status != pollers.PollingStatusSucceeded {
+		t.Fatalf("expected status to be %q but got %q", pollers.PollingStatusSucceeded, result.Status)
+	}
+	// sanity-checking
+	helpers.assertCalled(t, 1)
+}
+
+func TestPollerLRO_InStatus_ImmediateSuccess(t *testing.T) {
+	ctx := context.TODO()
+	helpers := newLongRunningOperationsEndpoint(false, []longRunningOperationsExpectedResponse{
+		responseWithStatus(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+	defer server.Close()
+
+	response := &client.Response{
+		Response: helpers.response(),
+	}
+	client := client.NewClient(server.URL, "MyService", "2020-02-01")
+	poller, err := longRunningOperationPollerFromResponse(response, client)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	t.Logf("Polling..")
+	result, err := poller.Poll(ctx)
+	if err != nil {
+		if result.Status == pollers.PollingStatusCancelled || result.Status == pollers.PollingStatusFailed {
+			return
+		}
+
+		t.Fatal(err.Error())
+	}
+	if result.Status != pollers.PollingStatusSucceeded {
+		t.Fatalf("expected status to be %q but got %q", pollers.PollingStatusSucceeded, result.Status)
+	}
+	// sanity-checking
+	helpers.assertCalled(t, 1)
+}
+
+func TestPollerLRO_InProvisioningState_AcceptedThenImmediateSuccess(t *testing.T) {
+	ctx := context.TODO()
+	helpers := newLongRunningOperationsEndpoint(true, []longRunningOperationsExpectedResponse{
+		responseWithHttpStatusCode(http.StatusAccepted),
+		responseWithStatus(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+	defer server.Close()
+
+	response := &client.Response{
+		Response: helpers.response(),
+	}
+	client := client.NewClient(server.URL, "MyService", "2020-02-01")
+	poller, err := longRunningOperationPollerFromResponse(response, client)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expectedStatuses := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress, // the 202 Accepted
+		pollers.PollingStatusSucceeded,  // good
+	}
+	for i, expected := range expectedStatuses {
+		t.Logf("Poll %d..", i)
+		result, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if result.Status != expected {
+			t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+		}
+	}
+	// sanity-checking
+	helpers.assertCalled(t, 2)
+}
+
+func TestPollerLRO_InStatus_AcceptedThenImmediateSuccess(t *testing.T) {
+	ctx := context.TODO()
+	helpers := newLongRunningOperationsEndpoint(false, []longRunningOperationsExpectedResponse{
+		responseWithHttpStatusCode(http.StatusAccepted),
+		responseWithStatus(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+	defer server.Close()
+
+	response := &client.Response{
+		Response: helpers.response(),
+	}
+	client := client.NewClient(server.URL, "MyService", "2020-02-01")
+	poller, err := longRunningOperationPollerFromResponse(response, client)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expectedStatuses := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress, // the 202 Accepted
+		pollers.PollingStatusSucceeded,  // good
+	}
+	for i, expected := range expectedStatuses {
+		t.Logf("Poll %d..", i)
+		result, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if result.Status != expected {
+			t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+		}
+	}
+	// sanity-checking
+	helpers.assertCalled(t, 2)
+}
+
+func TestPollerLRO_InProvisioningState_AcceptedThenInProgressThenSuccess(t *testing.T) {
+	ctx := context.TODO()
+	helpers := newLongRunningOperationsEndpoint(true, []longRunningOperationsExpectedResponse{
+		responseWithHttpStatusCode(http.StatusAccepted),
+		responseWithStatus(statusInProgress),
+		responseWithStatus(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+	defer server.Close()
+
+	response := &client.Response{
+		Response: helpers.response(),
+	}
+	client := client.NewClient(server.URL, "MyService", "2020-02-01")
+	poller, err := longRunningOperationPollerFromResponse(response, client)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expectedStatuses := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress, // the 202 Accepted
+		pollers.PollingStatusInProgress, // working on it
+		pollers.PollingStatusSucceeded,  // good
+	}
+	for i, expected := range expectedStatuses {
+		t.Logf("Poll %d..", i)
+		result, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if result.Status != expected {
+			t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+		}
+	}
+	// sanity-checking
+	helpers.assertCalled(t, 3)
+}
+
+func TestPollerLRO_InStatus_AcceptedThenInProgressThenSuccess(t *testing.T) {
+	ctx := context.TODO()
+	helpers := newLongRunningOperationsEndpoint(false, []longRunningOperationsExpectedResponse{
+		responseWithHttpStatusCode(http.StatusAccepted),
+		responseWithStatus(statusInProgress),
+		responseWithStatus(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+	defer server.Close()
+
+	response := &client.Response{
+		Response: helpers.response(),
+	}
+	client := client.NewClient(server.URL, "MyService", "2020-02-01")
+	poller, err := longRunningOperationPollerFromResponse(response, client)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expectedStatuses := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress, // the 202 Accepted
+		pollers.PollingStatusInProgress, // working on it
+		pollers.PollingStatusSucceeded,  // good
+	}
+	for i, expected := range expectedStatuses {
+		t.Logf("Poll %d..", i)
+		result, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if result.Status != expected {
+			t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+		}
+	}
+	// sanity-checking
+	helpers.assertCalled(t, 3)
+}
+
+func TestPollerLRO_InProvisioningState_404ThenImmediateSuccess(t *testing.T) {
+	// This scenario handles the API returning a 404 initially, then succeeded
+	// This happens when there's an API bug, since we shouldn't get the initial 404 - and can be
+	// seen in this issue: https://github.com/hashicorp/go-azure-sdk/issues/886 (although this test
+	// assumes we've immediately passed)
+	ctx := context.TODO()
+	helpers := newLongRunningOperationsEndpoint(true, []longRunningOperationsExpectedResponse{
+		responseWithHttpStatusCode(http.StatusNotFound),
+		responseWithStatus(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+	defer server.Close()
+
+	response := &client.Response{
+		Response: helpers.response(),
+	}
+	client := client.NewClient(server.URL, "MyService", "2020-02-01")
+	poller, err := longRunningOperationPollerFromResponse(response, client)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expectedStatuses := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress, // the 404
+		pollers.PollingStatusSucceeded,  // good
+	}
+	for i, expected := range expectedStatuses {
+		t.Logf("Poll %d..", i)
+		result, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if result.Status != expected {
+			t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+		}
+	}
+	// sanity-checking
+	helpers.assertCalled(t, 2)
+}
+
+func TestPollerLRO_InStatus_404ThenImmediateSuccess(t *testing.T) {
+	// This scenario handles the API returning a 404 initially, then succeeded
+	// This happens when there's an API bug, since we shouldn't get the initial 404 - and can be
+	// seen in this issue: https://github.com/hashicorp/go-azure-sdk/issues/886 (although this test
+	// assumes we've immediately passed)
+	ctx := context.TODO()
+	helpers := newLongRunningOperationsEndpoint(false, []longRunningOperationsExpectedResponse{
+		responseWithHttpStatusCode(http.StatusNotFound),
+		responseWithStatus(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+	defer server.Close()
+
+	response := &client.Response{
+		Response: helpers.response(),
+	}
+	client := client.NewClient(server.URL, "MyService", "2020-02-01")
+	poller, err := longRunningOperationPollerFromResponse(response, client)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expectedStatuses := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress, // the 404
+		pollers.PollingStatusSucceeded,  // good
+	}
+	for i, expected := range expectedStatuses {
+		t.Logf("Poll %d..", i)
+		result, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if result.Status != expected {
+			t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+		}
+	}
+	// sanity-checking
+	helpers.assertCalled(t, 2)
+}
+
+func TestPollerLRO_InProvisioningState_404ThenInProgressThenSucceeded(t *testing.T) {
+	// This scenario handles the API returning a 404 initially, then in progress, then succeeded
+	// This happens when there's an API bug, since we shouldn't get the initial 404 - and can be
+	// seen in this issue: https://github.com/hashicorp/go-azure-sdk/issues/886
+	ctx := context.TODO()
+	helpers := newLongRunningOperationsEndpoint(true, []longRunningOperationsExpectedResponse{
+		responseWithHttpStatusCode(http.StatusNotFound),
+		responseWithStatus(statusInProgress),
+		responseWithHttpStatusCode(http.StatusNotFound), // let's fake some eventual consistency
+		responseWithStatus(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+	defer server.Close()
+
+	response := &client.Response{
+		Response: helpers.response(),
+	}
+	client := client.NewClient(server.URL, "MyService", "2020-02-01")
+	poller, err := longRunningOperationPollerFromResponse(response, client)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expectedStatuses := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress, // the 404
+		pollers.PollingStatusInProgress, // the in progress
+		pollers.PollingStatusInProgress, // another 404 for good measure, call it eventual consistency
+		pollers.PollingStatusSucceeded,  // good
+	}
+	for i, expected := range expectedStatuses {
+		t.Logf("Poll %d..", i)
+		result, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if result.Status != expected {
+			t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+		}
+	}
+	// sanity-checking
+	helpers.assertCalled(t, 4)
+}
+
+func TestPollerLRO_InStatus_404ThenInProgressThenSucceeded(t *testing.T) {
+	// This scenario handles the API returning a 404 initially, then in progress, then succeeded
+	// This happens when there's an API bug, since we shouldn't get the initial 404 - and can be
+	// seen in this issue: https://github.com/hashicorp/go-azure-sdk/issues/886
+	ctx := context.TODO()
+	helpers := newLongRunningOperationsEndpoint(false, []longRunningOperationsExpectedResponse{
+		responseWithHttpStatusCode(http.StatusNotFound),
+		responseWithStatus(statusInProgress),
+		responseWithHttpStatusCode(http.StatusNotFound), // let's fake some eventual consistency
+		responseWithStatus(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helpers.endpoint(t)))
+	defer server.Close()
+
+	response := &client.Response{
+		Response: helpers.response(),
+	}
+	client := client.NewClient(server.URL, "MyService", "2020-02-01")
+	poller, err := longRunningOperationPollerFromResponse(response, client)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	expectedStatuses := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress, // the 404
+		pollers.PollingStatusInProgress, // the in progress
+		pollers.PollingStatusInProgress, // another 404 for good measure, call it eventual consistency
+		pollers.PollingStatusSucceeded,  // good
+	}
+	for i, expected := range expectedStatuses {
+		t.Logf("Poll %d..", i)
+		result, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if result.Status != expected {
+			t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+		}
+	}
+	// sanity-checking
+	helpers.assertCalled(t, 4)
+}

--- a/sdk/client/resourcemanager/poller_provisioning_state.go
+++ b/sdk/client/resourcemanager/poller_provisioning_state.go
@@ -143,13 +143,15 @@ func (p *provisioningStatePoller) Poll(ctx context.Context) (*pollers.PollResult
 }
 
 type provisioningStateResult struct {
-	Properties struct {
-		// Some API's (such as Storage) return the Resource Representation from the LRO API, as such we need to check provisioningState
-		ProvisioningState status `json:"provisioningState"`
-	} `json:"properties"`
+	Properties provisioningStateResultProperties `json:"properties"`
 
 	// others return Status, so we check that too
 	Status status `json:"status"`
+}
+
+type provisioningStateResultProperties struct {
+	// Some API's (such as Storage) return the Resource Representation from the LRO API, as such we need to check provisioningState
+	ProvisioningState status `json:"provisioningState"`
 }
 
 func resourceManagerResourcePathFromUri(input string) (*string, error) {

--- a/sdk/client/resourcemanager/poller_provisioning_state_helpers_test.go
+++ b/sdk/client/resourcemanager/poller_provisioning_state_helpers_test.go
@@ -94,6 +94,9 @@ func (e provisioningStateEndpoint) assertCalled(t *testing.T, expected int) {
 func (e provisioningStateEndpoint) response() *http.Response {
 	return &http.Response{
 		Header: map[string][]string{
+			// NOTE: any custom host/port is discarded, since we use the host from the Client when building the
+			// Poller - this is because we should only be hitting the ARM Endpoint (and using that token) so
+			// any differences (including regional endpoints, or custom ports) would be unexpected/an error.
 			http.CanonicalHeaderKey("Azure-AsyncOperation"): {"http://localhost/lro/poll"},
 			http.CanonicalHeaderKey("Retry-After"):          {"1"},
 		},

--- a/sdk/client/resourcemanager/poller_provisioning_state_helpers_test.go
+++ b/sdk/client/resourcemanager/poller_provisioning_state_helpers_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcemanager
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// provisioningStateEndpoint is a test helper struct which makes testing the expected behaviour of the
+// provisioning state logic easier.
+//
+// Ultimately this is faking an ARM Endpoint for the Resource - as such whilst we COULD expose superfluous
+// properties (id, location, name etc) there's little point since we ignore them, so I'm intentionally not
+// doing that here, since this is "good enough" for testing purposes.
+//
+// Originally these started out as a function per test, but with so much boilerplate, this helped make the
+// tests more readable, so whilst this has some boilerplate I suspect it's worth it for the tradeoff of
+// having tests that are more understandable.
+type provisioningStateEndpoint struct {
+	expectedApiVersion  string
+	numberOfTimesCalled int
+	responses           []expectedResponse
+}
+
+func newProvisioningStateEndpoint(responses []expectedResponse) provisioningStateEndpoint {
+	return provisioningStateEndpoint{
+		expectedApiVersion:  "2020-02-01",
+		numberOfTimesCalled: 0,
+		responses:           responses,
+	}
+}
+
+func (e *provisioningStateEndpoint) endpoint(t *testing.T) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("Server request %q %q", r.Method, r.RequestURI)
+
+		if r.Method != http.MethodGet && r.RequestURI != "/provisioning-state/poll" {
+			w.WriteHeader(http.StatusNotImplemented)
+			return
+		}
+		if apiv := r.URL.Query().Get("api-version"); apiv != e.expectedApiVersion {
+			w.WriteHeader(http.StatusNotImplemented)
+			t.Fatalf("expected the `api-version` to be set to `%s` but got %q", e.expectedApiVersion, apiv)
+			return
+		}
+
+		e.numberOfTimesCalled++
+		if e.numberOfTimesCalled > len(e.responses) {
+			t.Fatal("called too many times")
+		}
+		response := e.responses[e.numberOfTimesCalled-1]
+		if response.dropsConnection {
+			dropConnection(t, w)
+			return
+		}
+		if response.httpStatusCode != nil {
+			w.WriteHeader(*response.httpStatusCode)
+			return
+		}
+
+		if response.status == nil {
+			t.Fatalf("missing either a httpStatusCode or a status to return")
+		}
+		payload := operationResult{
+			Properties: operationResultProperties{
+				ProvisioningState: "",
+			},
+			Status: "",
+		}
+		if response.useProvisioningState {
+			payload.Properties.ProvisioningState = *response.status
+		}
+		if response.useStatus {
+			payload.Status = *response.status
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Fatalf(err.Error())
+			return
+		}
+	}
+}
+
+func (e provisioningStateEndpoint) assertCalled(t *testing.T, expected int) {
+	if e.numberOfTimesCalled != expected {
+		t.Fatalf("expected to be called %d times but got %d", expected, e.numberOfTimesCalled)
+	}
+}
+
+func (e provisioningStateEndpoint) response() *http.Response {
+	return &http.Response{
+		Header: map[string][]string{
+			http.CanonicalHeaderKey("Azure-AsyncOperation"): {"http://localhost/lro/poll"},
+			http.CanonicalHeaderKey("Retry-After"):          {"1"},
+		},
+	}
+}

--- a/sdk/client/resourcemanager/poller_provisioning_state_test.go
+++ b/sdk/client/resourcemanager/poller_provisioning_state_test.go
@@ -26,8 +26,9 @@ func TestPollerProvisioningState_InProvisioningState_Immediate(t *testing.T) {
 	defer server.Close()
 
 	resourceManagerClient := &Client{
-		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
-		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since we should be using
+		// `apiVersion` (which otherwise gets parsed from the URI in `provisioningStatePollerFromResponse`)
+		Client:     client.NewClient(server.URL, "Example", "2015-01-01"),
 		apiVersion: "2020-01-01",
 	}
 	poller := provisioningStatePoller{
@@ -90,8 +91,9 @@ func TestPollerProvisioningState_OkWithNoBody_Immediate(t *testing.T) {
 	defer server.Close()
 
 	resourceManagerClient := &Client{
-		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
-		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since we should be using
+		// `apiVersion` (which otherwise gets parsed from the URI in `provisioningStatePollerFromResponse`)
+		Client:     client.NewClient(server.URL, "Example", "2015-01-01"),
 		apiVersion: "2020-01-01",
 	}
 	poller := provisioningStatePoller{
@@ -124,8 +126,9 @@ func TestPollerProvisioningState_OkWithNoBody_AfterPolling(t *testing.T) {
 	defer server.Close()
 
 	resourceManagerClient := &Client{
-		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
-		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since we should be using
+		// `apiVersion` (which otherwise gets parsed from the URI in `provisioningStatePollerFromResponse`)
+		Client:     client.NewClient(server.URL, "Example", "2015-01-01"),
 		apiVersion: "2020-01-01",
 	}
 	poller := provisioningStatePoller{
@@ -168,8 +171,9 @@ func TestPollerProvisioningState_InProvisioningState_DroppedThenInProgressThenSu
 	defer server.Close()
 
 	resourceManagerClient := &Client{
-		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
-		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since we should be using
+		// `apiVersion` (which otherwise gets parsed from the URI in `provisioningStatePollerFromResponse`)
+		Client:     client.NewClient(server.URL, "Example", "2015-01-01"),
 		apiVersion: "2020-01-01",
 	}
 	poller := provisioningStatePoller{
@@ -215,8 +219,9 @@ func TestPollerProvisioningState_InStatus_DroppedThenInProgressThenSuccess(t *te
 	defer server.Close()
 
 	resourceManagerClient := &Client{
-		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
-		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since we should be using
+		// `apiVersion` (which otherwise gets parsed from the URI in `provisioningStatePollerFromResponse`)
+		Client:     client.NewClient(server.URL, "Example", "2015-01-01"),
 		apiVersion: "2020-01-01",
 	}
 	poller := provisioningStatePoller{
@@ -261,8 +266,9 @@ func TestPollerProvisioningState_InProvisioningState_Poll(t *testing.T) {
 	defer server.Close()
 
 	resourceManagerClient := &Client{
-		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
-		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since we should be using
+		// `apiVersion` (which otherwise gets parsed from the URI in `provisioningStatePollerFromResponse`)
+		Client:     client.NewClient(server.URL, "Example", "2015-01-01"),
 		apiVersion: "2020-01-01",
 	}
 	poller := provisioningStatePoller{

--- a/sdk/client/resourcemanager/poller_provisioning_state_test.go
+++ b/sdk/client/resourcemanager/poller_provisioning_state_test.go
@@ -1,0 +1,334 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcemanager
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+func TestPollerProvisioningState_InProvisioningState_Immediate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	// Ensure we're parsing from the `provisioningState` field
+	helper := newProvisioningStateEndpoint([]expectedResponse{
+		responseWithStatusInProvisioningState(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helper.endpoint(t)))
+	defer server.Close()
+
+	resourceManagerClient := &Client{
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
+		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		apiVersion: "2020-01-01",
+	}
+	poller := provisioningStatePoller{
+		apiVersion:           helper.expectedApiVersion,
+		client:               resourceManagerClient,
+		initialRetryDuration: 10,
+		originalUri:          "/provisioning-state/poll",
+		resourcePath:         "/provisioning-state/poll",
+	}
+	actual, err := poller.Poll(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.Status != pollers.PollingStatusSucceeded {
+		t.Fatalf("expected %q but got %q", string(pollers.PollingStatusSucceeded), string(actual.Status))
+	}
+}
+
+func TestPollerProvisioningState_InStatus_Immediate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	// Ensure we're parsing from the `status` field
+	helper := newProvisioningStateEndpoint([]expectedResponse{
+		responseWithStatusInStatusField(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helper.endpoint(t)))
+	defer server.Close()
+
+	resourceManagerClient := &Client{
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
+		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		apiVersion: "2020-01-01",
+	}
+	poller := provisioningStatePoller{
+		apiVersion:           helper.expectedApiVersion,
+		client:               resourceManagerClient,
+		initialRetryDuration: 10,
+		originalUri:          "/provisioning-state/poll",
+		resourcePath:         "/provisioning-state/poll",
+	}
+	actual, err := poller.Poll(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.Status != pollers.PollingStatusSucceeded {
+		t.Fatalf("expected %q but got %q", string(pollers.PollingStatusSucceeded), string(actual.Status))
+	}
+}
+
+func TestPollerProvisioningState_OkWithNoBody_Immediate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	// In this instance we're not setting any `status` value
+	helper := newProvisioningStateEndpoint([]expectedResponse{
+		responseWithHttpStatusCode(http.StatusOK),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helper.endpoint(t)))
+	defer server.Close()
+
+	resourceManagerClient := &Client{
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
+		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		apiVersion: "2020-01-01",
+	}
+	poller := provisioningStatePoller{
+		apiVersion:           helper.expectedApiVersion,
+		client:               resourceManagerClient,
+		initialRetryDuration: 10,
+		originalUri:          "/provisioning-state/poll",
+		resourcePath:         "/provisioning-state/poll",
+	}
+	actual, err := poller.Poll(ctx)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.Status != pollers.PollingStatusSucceeded {
+		t.Fatalf("expected %q but got %q", string(pollers.PollingStatusSucceeded), string(actual.Status))
+	}
+}
+
+func TestPollerProvisioningState_OkWithNoBody_AfterPolling(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	// changing where we're setting this for the heck of it
+	helper := newProvisioningStateEndpoint([]expectedResponse{
+		responseWithStatusInProvisioningState(statusInProgress), // intentionally in provisioningState
+		responseWithStatusInStatusField(statusInProgress),       // intentionally in status
+		responseWithHttpStatusCode(http.StatusOK),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helper.endpoint(t)))
+	defer server.Close()
+
+	resourceManagerClient := &Client{
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
+		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		apiVersion: "2020-01-01",
+	}
+	poller := provisioningStatePoller{
+		apiVersion:           helper.expectedApiVersion,
+		client:               resourceManagerClient,
+		initialRetryDuration: 10,
+		originalUri:          "/provisioning-state/poll",
+		resourcePath:         "/provisioning-state/poll",
+	}
+
+	expectedStates := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress,
+		pollers.PollingStatusInProgress,
+		pollers.PollingStatusSucceeded,
+	}
+	for i, expected := range expectedStates {
+		t.Logf("Poll %d..", i)
+		actual, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if actual.Status != expected {
+			t.Fatalf("expected %q but got %q", string(expected), string(actual.Status))
+		}
+	}
+}
+
+func TestPollerProvisioningState_InProvisioningState_DroppedThenInProgressThenSuccess(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	// changing where we're setting this for the heck of it
+	helper := newProvisioningStateEndpoint([]expectedResponse{
+		responseWithStatusInProvisioningState(statusInProgress),
+		responseThatDropsTheConnection(),
+		responseWithStatusInProvisioningState(statusInProgress),
+		responseWithStatusInProvisioningState(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helper.endpoint(t)))
+	defer server.Close()
+
+	resourceManagerClient := &Client{
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
+		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		apiVersion: "2020-01-01",
+	}
+	poller := provisioningStatePoller{
+		apiVersion:           helper.expectedApiVersion,
+		client:               resourceManagerClient,
+		initialRetryDuration: 10,
+		originalUri:          "/provisioning-state/poll",
+		resourcePath:         "/provisioning-state/poll",
+	}
+
+	expectedStatuses := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress, // working on it
+		// NOTE: the Dropped Connection will be ignored/silently retried
+		pollers.PollingStatusInProgress, // working on it
+		pollers.PollingStatusSucceeded,  // good
+	}
+	for i, expected := range expectedStatuses {
+		t.Logf("Poll %d..", i)
+		result, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if result.Status != expected {
+			t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+		}
+	}
+	// sanity-checking - expect 4 calls but 3 statuses (since the dropped connection is silently retried)
+	helper.assertCalled(t, 4)
+}
+
+func TestPollerProvisioningState_InStatus_DroppedThenInProgressThenSuccess(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	// changing where we're setting this for the heck of it
+	helper := newProvisioningStateEndpoint([]expectedResponse{
+		responseWithStatusInStatusField(statusInProgress),
+		responseThatDropsTheConnection(),
+		responseWithStatusInStatusField(statusInProgress),
+		responseWithStatusInStatusField(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helper.endpoint(t)))
+	defer server.Close()
+
+	resourceManagerClient := &Client{
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
+		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		apiVersion: "2020-01-01",
+	}
+	poller := provisioningStatePoller{
+		apiVersion:           helper.expectedApiVersion,
+		client:               resourceManagerClient,
+		initialRetryDuration: 10,
+		originalUri:          "/provisioning-state/poll",
+		resourcePath:         "/provisioning-state/poll",
+	}
+
+	expectedStatuses := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress, // working on it
+		// NOTE: the Dropped Connection will be ignored/silently retried
+		pollers.PollingStatusInProgress, // working on it
+		pollers.PollingStatusSucceeded,  // good
+	}
+	for i, expected := range expectedStatuses {
+		t.Logf("Poll %d..", i)
+		result, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if result.Status != expected {
+			t.Fatalf("expected status to be %q but got %q", expected, result.Status)
+		}
+	}
+	// sanity-checking - expect 4 calls but 3 statuses (since the dropped connection is silently retried)
+	helper.assertCalled(t, 4)
+}
+
+func TestPollerProvisioningState_InProvisioningState_Poll(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	// changing where we're setting this for the heck of it
+	helper := newProvisioningStateEndpoint([]expectedResponse{
+		responseWithStatusInProvisioningState(statusInProgress),
+		responseWithStatusInProvisioningState(statusInProgress),
+		responseWithStatusInProvisioningState(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helper.endpoint(t)))
+	defer server.Close()
+
+	resourceManagerClient := &Client{
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
+		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		apiVersion: "2020-01-01",
+	}
+	poller := provisioningStatePoller{
+		apiVersion:           helper.expectedApiVersion,
+		client:               resourceManagerClient,
+		initialRetryDuration: 10,
+		originalUri:          "/provisioning-state/poll",
+		resourcePath:         "/provisioning-state/poll",
+	}
+
+	expectedStates := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress,
+		pollers.PollingStatusInProgress,
+		pollers.PollingStatusSucceeded,
+	}
+	for i, expected := range expectedStates {
+		t.Logf("Poll %d..", i)
+		actual, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if actual.Status != expected {
+			t.Fatalf("expected %q but got %q", string(expected), string(actual.Status))
+		}
+	}
+}
+
+func TestPollerProvisioningState_InStatus_Poll(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	// changing where we're setting this for the heck of it
+	helper := newProvisioningStateEndpoint([]expectedResponse{
+		responseWithStatusInStatusField(statusInProgress),
+		responseWithStatusInStatusField(statusInProgress),
+		responseWithStatusInStatusField(statusSucceeded),
+	})
+	server := httptest.NewServer(http.HandlerFunc(helper.endpoint(t)))
+	defer server.Close()
+
+	resourceManagerClient := &Client{
+		// NOTE: the use of a different API Version here is _intentional_ to ensure it's unused since the
+		Client:     client.NewClient(server.URL, "Example", "2020-01-01"),
+		apiVersion: "2020-01-01",
+	}
+	poller := provisioningStatePoller{
+		apiVersion:           helper.expectedApiVersion,
+		client:               resourceManagerClient,
+		initialRetryDuration: 10,
+		originalUri:          "/provisioning-state/poll",
+		resourcePath:         "/provisioning-state/poll",
+	}
+
+	expectedStates := []pollers.PollingStatus{
+		pollers.PollingStatusInProgress,
+		pollers.PollingStatusInProgress,
+		pollers.PollingStatusSucceeded,
+	}
+	for i, expected := range expectedStates {
+		t.Logf("Poll %d..", i)
+		actual, err := poller.Poll(ctx)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if actual.Status != expected {
+			t.Fatalf("expected %q but got %q", string(expected), string(actual.Status))
+		}
+	}
+}


### PR DESCRIPTION
This PR updates the `LRO` poller to treat 404's as `InProgress`, which should fix https://github.com/hashicorp/go-azure-sdk/issues/989

Whilst threading this through I've also added some tests which make use of a fake HTTP server to both more realistically test both the LRO and ProvisioningState poller - but also (hopefully) better explain the scenarios to other contributors.