### PR TITLE
Add AwaitingManualAction status

### DIFF
--- a/sdk/client/resourcemanager/poller_lro_statuses.go
+++ b/sdk/client/resourcemanager/poller_lro_statuses.go
@@ -103,4 +103,7 @@ var longRunningOperationCustomStatuses = map[status]pollers.PollingStatus{
 
 	// StorageSync@2020-03-01 returns `validateInput` rather than `InProgress` during creation/update (https://github.com/hashicorp/go-azure-sdk/issues/565)
 	"validateInput": pollers.PollingStatusInProgress,
+
+	// EventGrid @ 2022-06-15 returns `AwaitingManualAction` while waiting for manual validation of a webhook (https://github.com/hashicorp/terraform-provider-azurerm/issues/25689)
+	"AwaitingManualAction": pollers.PollingStatusInProgress,
 }


### PR DESCRIPTION
Adding AwaitingManualAction status, which is returned when we are creating an Event subscription with manual webhook validation

polling after CreateOrUpdate: result.Status was nil/empty - op.Status was "AwaitingManualAction" / op.Properties.ProvisioningState was ""