### PR TITLE
`sdk`: provisioning state poller allow additional parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .fleet/
 .idea/
+.vscode/
 .DS_Store
 tmp/
 vendor/


### PR DESCRIPTION
This PR is to fix issues that provisioning state poller may need additional query parameters to request the resource.

Possibly unblocks #962, https://github.com/hashicorp/terraform-provider-azurerm/issues/23322 and https://github.com/hashicorp/terraform-provider-azurerm/issues/24379

## Issue description
For the APIM API resource, the response to a create/update operation includes a `location` header with an `asyncId` parameter. This `asyncId` is needed to retrieve the actual error message if the create/update operation fails.

![image](https://github.com/user-attachments/assets/a1137358-e3c7-4ad4-9b45-edfa802c8856)


### Create
If missing the asyncId parameter, the GET operation after a failed creation will return 404 Not Found, obscuring the actual ValidationError.

![image](https://github.com/user-attachments/assets/040f5372-8439-4a7a-bf5f-966196a91058)

When this PR is applied, the error message will reflect the root cause as follows:

![image](https://github.com/user-attachments/assets/3aba38b8-ad21-4be2-980d-30f7d4525bf0)

### Update
The GET operation after a failed update will return 200 OK, mistakenly indicating the update was successful. More details can be found at https://github.com/hashicorp/terraform-provider-azurerm/issues/24379.

When this PR is applied, the update operation will report the error if the swagger contains validation error:

![image](https://github.com/user-attachments/assets/fc9244e0-030d-4caf-a927-bd117744d255)


