### PR TITLE
handle empty `nextlink` value as end of pagination

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -699,7 +699,7 @@ func (c *Client) retryableClient(ctx context.Context, checkRetry retryablehttp.C
 	// This results into the following N(t) (by guaranteeing T(n) <= t):
 	// - n = floor(log(t+1)) - 1 		(0<=t<=63)
 	// - n = (t - 63)/61 + 6 			(t > 63)
-	safeRetryNumber := func(t time.Duration) int {
+	var safeRetryNumber = func(t time.Duration) int {
 		sec := t.Seconds()
 		if sec <= 63 {
 			return int(math.Floor(math.Log2(sec+1))) - 1

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -615,7 +615,7 @@ func (c *Client) ExecutePaged(ctx context.Context, req *Request) (*Response, err
 			return resp, err
 		}
 	}
-	if nextLink == nil {
+	if nextLink == nil || string(*nextLink) == "" {
 		// This is the last page
 		return resp, nil
 	}
@@ -699,7 +699,7 @@ func (c *Client) retryableClient(ctx context.Context, checkRetry retryablehttp.C
 	// This results into the following N(t) (by guaranteeing T(n) <= t):
 	// - n = floor(log(t+1)) - 1 		(0<=t<=63)
 	// - n = (t - 63)/61 + 6 			(t > 63)
-	var safeRetryNumber = func(t time.Duration) int {
+	safeRetryNumber := func(t time.Duration) int {
 		sec := t.Seconds()
 		if sec <= 63 {
 			return int(math.Floor(math.Log2(sec+1))) - 1


### PR DESCRIPTION
The `chaos` return an empty string in the `NextLink` property instead of set it to `null` when calling [`TargetTypes_List`
](https://github.com/Azure/azure-rest-api-specs/blob/8ad58020cfafc5ace71d85b31272acf4d6b694d3/specification/chaos/resource-manager/Microsoft.Chaos/stable/2023-11-01/targetTypes.json#L43C25-L43C41). It will make the provider wait endless...

I have opened an [issue](https://github.com/Azure/azure-rest-api-specs/issues/31098) on azure-rest-api-specs repo, but can we consider add this workaround to avoid similar bad cases?