### PR TITLE
exclude Resource Manager endpoints from network failure detection

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -471,8 +471,13 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 		// Check for failed connections etc and decide if retries are appropriate
 		if r == nil {
 			if req.IsIdempotent() {
-				return extendedRetryPolicy(r, err)
+				if !isResourceMangerHost(req) {
+					return extendedRetryPolicy(r, err)
+				}
+
+				return retryablehttp.DefaultRetryPolicy(ctx, r, err)
 			}
+
 			return false, fmt.Errorf("HTTP response was nil; connection may have been reset")
 		}
 
@@ -754,6 +759,7 @@ func containsStatusCode(expected []int, actual int) bool {
 
 // extendedRetryPolicy extends the defaultRetryPolicy implementation in go-retryablehhtp with
 // additional error conditions that should not be retried indefinitely
+// TODO - This should be removed as part of 5.0 release of AzureRM, and the base layer returned to the `retryablehttp.DefaultRetryPolicy` for all requests.
 func extendedRetryPolicy(resp *http.Response, err error) (bool, error) {
 	// A regular expression to match the error returned by net/http when the
 	// configured number of redirects is exhausted. This error isn't typed
@@ -839,4 +845,23 @@ func extendedRetryPolicy(resp *http.Response, err error) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// exclude Resource Manager calls from the network failure retry avoidance to help users on unreliable networks
+// This code path should be removed when the Data Plane separation work is completed and 5.0 ships.
+func isResourceMangerHost(req *Request) bool {
+	knownResourceManagerHosts := []string{
+		"management.azure.com",
+		"management.chinacloudapi.cn",
+		"management.usgovcloudapi.net",
+	}
+	if url := req.Request.URL; url != nil {
+		for _, host := range knownResourceManagerHosts {
+			if strings.Contains(url.Host, host) {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -471,7 +471,7 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 		// Check for failed connections etc and decide if retries are appropriate
 		if r == nil {
 			if req.IsIdempotent() {
-				if !isResourceMangerHost(req) {
+				if !isResourceManagerHost(req) {
 					return extendedRetryPolicy(r, err)
 				}
 
@@ -849,7 +849,7 @@ func extendedRetryPolicy(resp *http.Response, err error) (bool, error) {
 
 // exclude Resource Manager calls from the network failure retry avoidance to help users on unreliable networks
 // This code path should be removed when the Data Plane separation work is completed and 5.0 ships.
-func isResourceMangerHost(req *Request) bool {
+func isResourceManagerHost(req *Request) bool {
 	knownResourceManagerHosts := []string{
 		"management.azure.com",
 		"management.chinacloudapi.cn",

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/go-azure-sdk/sdk
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Azure/go-autorest/autorest v0.11.29


### PR DESCRIPTION
Users on unstable/unreliable networks can experience terraform operation disruption. Since the extendedRetryPolicy is needed only for Data Plane clients, this PR restores previous "Retry Forever" (specifically until operation context deadline expires) behaviour for Resource Manager  endpoints.

* bump go to `1.22`
* exclude azure management endpoints from network failure logic.