### PR TITLE
SDK LRO Poller: Rest the result.HttpResponse.Body before returning

### DIFF
--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -194,6 +194,7 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			if parseError != nil {
 				return nil, parseError
 			}
+			result.HttpResponse.Body = io.NopCloser(bytes.NewReader(respBody))
 
 			err = pollers.PollingFailedError{
 				HttpResponse: result.HttpResponse,
@@ -206,6 +207,7 @@ func (p *longRunningOperationPoller) Poll(ctx context.Context) (result *pollers.
 			if parseError != nil {
 				return nil, parseError
 			}
+			result.HttpResponse.Body = io.NopCloser(bytes.NewReader(respBody))
 
 			err = pollers.PollingCancelledError{
 				HttpResponse: result.HttpResponse,


### PR DESCRIPTION
The `longRunningOperationPoller.Poll` can return different poller errors, including:

- `pollers.PollingFailedError`
- `pollers.PollingCancelledError`

These two errors contain a `HttpResponse` field and a `Message` field. As a consumer of this error type, one will likely read the body from the `HttpResponse`, e.g., Azure Private Endpoint can return the following LRO responses:

```json
{
  "status": "Failed",
  "error": {
    "code": "RetryableError",
    "message": "A retryable error occurred.",
    "details": [
      {
        "code": "ReferencedResourceNotProvisioned",
        "message": "Cannot proceed with operation because resource /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/acctest-mgd-petestt4/providers/Microsoft.Network/virtualNetworks/virtnetnamex/subnets/ssub3 used by resource /subscriptions/0b1f6471-1bf0-4dda-aec3-cb9272f09590/resourceGroups/acctest-mgd-petestt4/providers/Microsoft.Network/networkInterfaces/example-endpoint-in-ssub3.nic.b1ecd3e7-fbcb-4e40-960b-5e7937dd8b66 is not in Succeeded state. Resource is in Updating state and the last operation that updated/is updating the resource is PutSubnetOperation."
      }
    ]
  }
}
```


```json
{
  "status": "Failed",
  "error": {
    "code": "StorageAccountOperationInProgress",
    "message": "Call to Microsoft.Storage/storageAccounts failed. Error message: An operation is currently performing on this storage account that requires exclusive access.",
    "details": []
  }
}
```

Both are *retryable*, though it is not a good idea to embed this retry logic in the `SDK` itself. It'd be better to do it per resource type. Therefore, accessing the latest response of the LRO, and inspect the error code shall be done.

Currently, the `HttpResponse` is initially reset right after directly read in this function:

https://github.com/hashicorp/go-azure-sdk/blob/774530e0b667b47c028f62e61770dba2e7aeb441/sdk/client/resourcemanager/poller_lro.go#L130-L138

While it is later consumed indirectly by the call below:

https://github.com/hashicorp/go-azure-sdk/blob/774530e0b667b47c028f62e61770dba2e7aeb441/sdk/client/resourcemanager/poller_lro.go#L206-L209

This PR resets the response back right after this function call.

Aside: It might be tempted to use the `LatestResponse()` method from the poller to get the latest response body. Unfortunately, the current implementation of `PollUntillDone` will set it to nil on error: https://github.com/hashicorp/go-azure-sdk/blob/774530e0b667b47c028f62e61770dba2e7aeb441/sdk/client/pollers/poller.go#L208-L210

Aside2: The `CreateOrUpdateThenPoll` method currently generated is not wrapping the poll error: https://github.com/hashicorp/go-azure-sdk/blob/774530e0b667b47c028f62e61770dba2e7aeb441/resource-manager/web/2023-12-01/domains/method_createorupdate.go#L70-L72

This makes users have no way to cast the error to any of the poller errors. The only workaround is to split the call to `CreateOrUpdate` + `PollUntillDone`.