### PR TITLE
poller_lro : add pending status Restarting for Postgres

### DIFF
--- a/sdk/client/resourcemanager/poller_lro_statuses.go
+++ b/sdk/client/resourcemanager/poller_lro_statuses.go
@@ -86,6 +86,9 @@ var longRunningOperationCustomStatuses = map[status]pollers.PollingStatus{
 	// Resources @ 2020-10-01 (DeploymentScripts) returns `ProvisioningResources` during Creation
 	"ProvisioningResources": pollers.PollingStatusInProgress,
 
+	// Postgres @ 2021-06-01 returns `Restarting` during restart
+	"Restarting": pollers.PollingStatusInProgress,
+
 	// AnalysisServices @ 2017-08-01 (Servers Resume) returns `Resuming` during Update
 	"Resuming": pollers.PollingStatusInProgress,
 


### PR DESCRIPTION
As TF would [restart](https://github.com/hashicorp/terraform-provider-azurerm/blob/6eb4009c77dd47d34989ac97c39a85ac711aff34/internal/services/postgres/postgresql_flexible_server_configuration_resource.go#L112) Postgresql Flexible Server while configuring server parameters,  the intermediate state "Restarting" will be hit.

API response:
```
{
  ......
  "properties": {
    ......
    "state": "Restarting",
    ......
  },
  ......
  "type": "Microsoft.DBforPostgreSQL/flexibleServers"
}
```


fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/28298