### PR TITLE
[CODEOWNERS] - add ADR required reviewers for DeviceRegistry directory to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 *  @hashicorp/terraform-azure
 
 # PRLabel: %Device Registry
-/resource-manager/deviceregistry/ @marcodalessandro @rohankhandelwal @riteshrao
+/resource-manager/deviceregistry/ @marcodalessandro @rohankhandelwal @riteshrao @davidemontanari

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 *  @hashicorp/terraform-azure
+
+# PRLabel: %Device Registry
+/resource-manager/deviceregistry/ @marcodalessandro @rohankhandelwal @riteshrao


### PR DESCRIPTION
Adding ADR required reviewers to the CODEOWNERS file so that any updates to the golang hashicorp azure sdk will be flagged and we can be aware of the changes.