### PR TITLE
fix: Use url.JoinPath() to more flexibly handle extraneous slashes

### DIFF
--- a/sdk/auth/client_secret_authorizer.go
+++ b/sdk/auth/client_secret_authorizer.go
@@ -83,7 +83,11 @@ func (a *ClientSecretAuthorizer) Token(ctx context.Context, _ *http.Request) (*o
 		if a.conf.Environment.Authorization == nil {
 			return nil, fmt.Errorf("no `authorization` configuration was found for this environment")
 		}
-		tokenUrl = tokenEndpoint(*a.conf.Environment.Authorization, a.conf.TenantID)
+		var err error
+		tokenUrl, err = tokenEndpoint(*a.conf.Environment.Authorization, a.conf.TenantID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return clientCredentialsToken(ctx, tokenUrl, &v)
@@ -118,7 +122,11 @@ func (a *ClientSecretAuthorizer) AuxiliaryTokens(ctx context.Context, _ *http.Re
 			if a.conf.Environment.Authorization == nil {
 				return nil, fmt.Errorf("no `authorization` configuration was found for this environment")
 			}
-			tokenUrl = tokenEndpoint(*a.conf.Environment.Authorization, tenantId)
+			var err error
+			tokenUrl, err = tokenEndpoint(*a.conf.Environment.Authorization, tenantId)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		token, err := clientCredentialsToken(ctx, tokenUrl, &v)

--- a/sdk/internal/metadata/client.go
+++ b/sdk/internal/metadata/client.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"runtime"
 	"time"
 )
@@ -52,7 +53,12 @@ func (c *Client) GetMetaData(ctx context.Context) (*MetaData, error) {
 			MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
 		},
 	}
-	uri := fmt.Sprintf("%s/metadata/endpoints?api-version=2022-09-01", c.endpoint)
+	uri, err := url.JoinPath(c.endpoint, "/metadata/endpoints")
+	if err != nil {
+		return nil, fmt.Errorf("parsing endpoint: %+v", err)
+	}
+	uri += "?api-version=2022-09-01"
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, fmt.Errorf("preparing request: %+v", err)


### PR DESCRIPTION
In a custom cloud environment, we configure terraform-provider-azurerm with a `metadata_host` whose response to `GET /metadata/endpoints?api-version=2022-09-01` includes a trailing slash in the `loginEndpoint` field. The current `Sprintf` approach assumes well formed (no slashes) endpoints. The provider fails to get OIDC credentials in this environment due to the double slash at the beginning of the path returned by tokenEndpoint().

In order to be more robust to this subtly unepected input, the provider can use [url.JoinPath](https://pkg.go.dev/net/url#JoinPath) to clean missing and double slashes.