### PR TITLE
[sdk/client] - parsing error text from OData contain the raw details message 

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -11,7 +11,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
 	"io"
 	"log"
 	"math"
@@ -27,6 +26,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
 	"github.com/hashicorp/go-azure-sdk/sdk/internal/accept"
 	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 // RetryOn404ConsistencyFailureFunc can be used to retry a request when a 404 response is received


### PR DESCRIPTION
Fix SDK [#1175](https://github.com/hashicorp/go-azure-sdk/issues/1175) which fixes [#29033](https://github.com/hashicorp/terraform-provider-azurerm/issues/29033).


