### PR TITLE
Fix disk grant access

### DIFF
--- a/resource-manager/compute/2022-03-02/disks/model_accessuri.go
+++ b/resource-manager/compute/2022-03-02/disks/model_accessuri.go
@@ -4,6 +4,9 @@ package disks
 // Licensed under the MIT License. See NOTICE.txt in the project root for license information.
 
 type AccessUri struct {
-	AccessSAS             *string `json:"accessSAS,omitempty"`
-	SecurityDataAccessSAS *string `json:"securityDataAccessSAS,omitempty"`
+	StartTime  *string              `json:"startTime,omitempty"`
+	EndTime    *string              `json:"endTime,omitempty"`
+	Status     *string              `json:"status,omitempty"`
+	Name       *string              `json:"name,omitempty"`
+	Properties *AccessUriProperties `json:"properties,omitempty"`
 }

--- a/resource-manager/compute/2022-03-02/disks/model_accessurioutput.go
+++ b/resource-manager/compute/2022-03-02/disks/model_accessurioutput.go
@@ -1,0 +1,8 @@
+package disks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessUriOutput struct {
+	AccessSAS *string `json:"accessSAS,omitempty"`
+}

--- a/resource-manager/compute/2022-03-02/disks/model_accessuriproperties.go
+++ b/resource-manager/compute/2022-03-02/disks/model_accessuriproperties.go
@@ -1,0 +1,8 @@
+package disks
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AccessUriProperties struct {
+	Output *AccessUriOutput `json:"output,omitempty"`
+}


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 
If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->
1. Access URI of the disk should be returned from `GrantAccessThenPoll`, so the return value of this function is changed.
2. `AccessUri` in `GrantAccessOperationResponse` doesn't match the actual one, which leads to unmarshal failure. Added and changed the fields of the struct.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes #0000


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
