### PR TITLE
Update "I P" to "IP" everywhere

### DIFF
--- a/resource-manager/network/2023-09-01/customipprefixes/id_customipprefix.go
+++ b/resource-manager/network/2023-09-01/customipprefixes/id_customipprefix.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &CustomIPPrefixId{}
 
-// CustomIPPrefixId is a struct representing the Resource ID for a Custom I P Prefix
+// CustomIPPrefixId is a struct representing the Resource ID for a Custom IP Prefix
 type CustomIPPrefixId struct {
 	SubscriptionId     string
 	ResourceGroupName  string
@@ -84,7 +84,7 @@ func (id *CustomIPPrefixId) FromParseResult(input resourceids.ParseResult) error
 	return nil
 }
 
-// ValidateCustomIPPrefixID checks that 'input' can be parsed as a Custom I P Prefix ID
+// ValidateCustomIPPrefixID checks that 'input' can be parsed as a Custom IP Prefix ID
 func ValidateCustomIPPrefixID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateCustomIPPrefixID(input interface{}, key string) (warnings []string,
 	return
 }
 
-// ID returns the formatted Custom I P Prefix ID
+// ID returns the formatted Custom IP Prefix ID
 func (id CustomIPPrefixId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/customIPPrefixes/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CustomIPPrefixName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Custom I P Prefix ID
+// Segments returns a slice of Resource ID Segments which comprise this Custom IP Prefix ID
 func (id CustomIPPrefixId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id CustomIPPrefixId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Custom I P Prefix ID
+// String returns a human-readable description of this Custom IP Prefix ID
 func (id CustomIPPrefixId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
-		fmt.Sprintf("Custom I P Prefix Name: %q", id.CustomIPPrefixName),
+		fmt.Sprintf("Custom IP Prefix Name: %q", id.CustomIPPrefixName),
 	}
-	return fmt.Sprintf("Custom I P Prefix (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Custom IP Prefix (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2023-09-01/ipallocations/id_ipallocation.go
+++ b/resource-manager/network/2023-09-01/ipallocations/id_ipallocation.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &IPAllocationId{}
 
-// IPAllocationId is a struct representing the Resource ID for a I P Allocation
+// IPAllocationId is a struct representing the Resource ID for a IP Allocation
 type IPAllocationId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -84,7 +84,7 @@ func (id *IPAllocationId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidateIPAllocationID checks that 'input' can be parsed as a I P Allocation ID
+// ValidateIPAllocationID checks that 'input' can be parsed as a IP Allocation ID
 func ValidateIPAllocationID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateIPAllocationID(input interface{}, key string) (warnings []string, e
 	return
 }
 
-// ID returns the formatted I P Allocation ID
+// ID returns the formatted IP Allocation ID
 func (id IPAllocationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/ipAllocations/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.IpAllocationName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this I P Allocation ID
+// Segments returns a slice of Resource ID Segments which comprise this IP Allocation ID
 func (id IPAllocationId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id IPAllocationId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this I P Allocation ID
+// String returns a human-readable description of this IP Allocation ID
 func (id IPAllocationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Ip Allocation Name: %q", id.IpAllocationName),
 	}
-	return fmt.Sprintf("I P Allocation (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("IP Allocation (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2023-09-01/ipgroups/id_ipgroup.go
+++ b/resource-manager/network/2023-09-01/ipgroups/id_ipgroup.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &IPGroupId{}
 
-// IPGroupId is a struct representing the Resource ID for a I P Group
+// IPGroupId is a struct representing the Resource ID for a IP Group
 type IPGroupId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -84,7 +84,7 @@ func (id *IPGroupId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidateIPGroupID checks that 'input' can be parsed as a I P Group ID
+// ValidateIPGroupID checks that 'input' can be parsed as a IP Group ID
 func ValidateIPGroupID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateIPGroupID(input interface{}, key string) (warnings []string, errors
 	return
 }
 
-// ID returns the formatted I P Group ID
+// ID returns the formatted IP Group ID
 func (id IPGroupId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/ipGroups/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.IpGroupName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this I P Group ID
+// Segments returns a slice of Resource ID Segments which comprise this IP Group ID
 func (id IPGroupId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id IPGroupId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this I P Group ID
+// String returns a human-readable description of this IP Group ID
 func (id IPGroupId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Ip Group Name: %q", id.IpGroupName),
 	}
-	return fmt.Sprintf("I P Group (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("IP Group (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2023-09-01/loadbalancers/id_frontendipconfiguration.go
+++ b/resource-manager/network/2023-09-01/loadbalancers/id_frontendipconfiguration.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &FrontendIPConfigurationId{}
 
-// FrontendIPConfigurationId is a struct representing the Resource ID for a Frontend I P Configuration
+// FrontendIPConfigurationId is a struct representing the Resource ID for a Frontend IP Configuration
 type FrontendIPConfigurationId struct {
 	SubscriptionId              string
 	ResourceGroupName           string
@@ -90,7 +90,7 @@ func (id *FrontendIPConfigurationId) FromParseResult(input resourceids.ParseResu
 	return nil
 }
 
-// ValidateFrontendIPConfigurationID checks that 'input' can be parsed as a Frontend I P Configuration ID
+// ValidateFrontendIPConfigurationID checks that 'input' can be parsed as a Frontend IP Configuration ID
 func ValidateFrontendIPConfigurationID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -105,13 +105,13 @@ func ValidateFrontendIPConfigurationID(input interface{}, key string) (warnings 
 	return
 }
 
-// ID returns the formatted Frontend I P Configuration ID
+// ID returns the formatted Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.LoadBalancerName, id.FrontendIPConfigurationName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Frontend I P Configuration ID
+// Segments returns a slice of Resource ID Segments which comprise this Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -127,13 +127,13 @@ func (id FrontendIPConfigurationId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Frontend I P Configuration ID
+// String returns a human-readable description of this Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Load Balancer Name: %q", id.LoadBalancerName),
-		fmt.Sprintf("Frontend I P Configuration Name: %q", id.FrontendIPConfigurationName),
+		fmt.Sprintf("Frontend IP Configuration Name: %q", id.FrontendIPConfigurationName),
 	}
-	return fmt.Sprintf("Frontend I P Configuration (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Frontend IP Configuration (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2023-09-01/publicipprefixes/id_publicipprefix.go
+++ b/resource-manager/network/2023-09-01/publicipprefixes/id_publicipprefix.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &PublicIPPrefixId{}
 
-// PublicIPPrefixId is a struct representing the Resource ID for a Public I P Prefix
+// PublicIPPrefixId is a struct representing the Resource ID for a Public IP Prefix
 type PublicIPPrefixId struct {
 	SubscriptionId     string
 	ResourceGroupName  string
@@ -84,7 +84,7 @@ func (id *PublicIPPrefixId) FromParseResult(input resourceids.ParseResult) error
 	return nil
 }
 
-// ValidatePublicIPPrefixID checks that 'input' can be parsed as a Public I P Prefix ID
+// ValidatePublicIPPrefixID checks that 'input' can be parsed as a Public IP Prefix ID
 func ValidatePublicIPPrefixID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidatePublicIPPrefixID(input interface{}, key string) (warnings []string,
 	return
 }
 
-// ID returns the formatted Public I P Prefix ID
+// ID returns the formatted Public IP Prefix ID
 func (id PublicIPPrefixId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/publicIPPrefixes/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.PublicIPPrefixName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Public I P Prefix ID
+// Segments returns a slice of Resource ID Segments which comprise this Public IP Prefix ID
 func (id PublicIPPrefixId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id PublicIPPrefixId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Public I P Prefix ID
+// String returns a human-readable description of this Public IP Prefix ID
 func (id PublicIPPrefixId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
-		fmt.Sprintf("Public I P Prefix Name: %q", id.PublicIPPrefixName),
+		fmt.Sprintf("Public IP Prefix Name: %q", id.PublicIPPrefixName),
 	}
-	return fmt.Sprintf("Public I P Prefix (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Public IP Prefix (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2023-11-01/customipprefixes/id_customipprefix.go
+++ b/resource-manager/network/2023-11-01/customipprefixes/id_customipprefix.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &CustomIPPrefixId{}
 
-// CustomIPPrefixId is a struct representing the Resource ID for a Custom I P Prefix
+// CustomIPPrefixId is a struct representing the Resource ID for a Custom IP Prefix
 type CustomIPPrefixId struct {
 	SubscriptionId     string
 	ResourceGroupName  string
@@ -84,7 +84,7 @@ func (id *CustomIPPrefixId) FromParseResult(input resourceids.ParseResult) error
 	return nil
 }
 
-// ValidateCustomIPPrefixID checks that 'input' can be parsed as a Custom I P Prefix ID
+// ValidateCustomIPPrefixID checks that 'input' can be parsed as a Custom IP Prefix ID
 func ValidateCustomIPPrefixID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateCustomIPPrefixID(input interface{}, key string) (warnings []string,
 	return
 }
 
-// ID returns the formatted Custom I P Prefix ID
+// ID returns the formatted Custom IP Prefix ID
 func (id CustomIPPrefixId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/customIPPrefixes/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CustomIPPrefixName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Custom I P Prefix ID
+// Segments returns a slice of Resource ID Segments which comprise this Custom IP Prefix ID
 func (id CustomIPPrefixId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id CustomIPPrefixId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Custom I P Prefix ID
+// String returns a human-readable description of this Custom IP Prefix ID
 func (id CustomIPPrefixId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
-		fmt.Sprintf("Custom I P Prefix Name: %q", id.CustomIPPrefixName),
+		fmt.Sprintf("Custom IP Prefix Name: %q", id.CustomIPPrefixName),
 	}
-	return fmt.Sprintf("Custom I P Prefix (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Custom IP Prefix (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2023-11-01/ipallocations/id_ipallocation.go
+++ b/resource-manager/network/2023-11-01/ipallocations/id_ipallocation.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &IPAllocationId{}
 
-// IPAllocationId is a struct representing the Resource ID for a I P Allocation
+// IPAllocationId is a struct representing the Resource ID for a IP Allocation
 type IPAllocationId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -84,7 +84,7 @@ func (id *IPAllocationId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidateIPAllocationID checks that 'input' can be parsed as a I P Allocation ID
+// ValidateIPAllocationID checks that 'input' can be parsed as a IP Allocation ID
 func ValidateIPAllocationID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateIPAllocationID(input interface{}, key string) (warnings []string, e
 	return
 }
 
-// ID returns the formatted I P Allocation ID
+// ID returns the formatted IP Allocation ID
 func (id IPAllocationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/ipAllocations/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.IpAllocationName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this I P Allocation ID
+// Segments returns a slice of Resource ID Segments which comprise this IP Allocation ID
 func (id IPAllocationId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id IPAllocationId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this I P Allocation ID
+// String returns a human-readable description of this IP Allocation ID
 func (id IPAllocationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Ip Allocation Name: %q", id.IpAllocationName),
 	}
-	return fmt.Sprintf("I P Allocation (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("IP Allocation (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2023-11-01/ipgroups/id_ipgroup.go
+++ b/resource-manager/network/2023-11-01/ipgroups/id_ipgroup.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &IPGroupId{}
 
-// IPGroupId is a struct representing the Resource ID for a I P Group
+// IPGroupId is a struct representing the Resource ID for a IP Group
 type IPGroupId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -84,7 +84,7 @@ func (id *IPGroupId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidateIPGroupID checks that 'input' can be parsed as a I P Group ID
+// ValidateIPGroupID checks that 'input' can be parsed as a IP Group ID
 func ValidateIPGroupID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateIPGroupID(input interface{}, key string) (warnings []string, errors
 	return
 }
 
-// ID returns the formatted I P Group ID
+// ID returns the formatted IP Group ID
 func (id IPGroupId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/ipGroups/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.IpGroupName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this I P Group ID
+// Segments returns a slice of Resource ID Segments which comprise this IP Group ID
 func (id IPGroupId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id IPGroupId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this I P Group ID
+// String returns a human-readable description of this IP Group ID
 func (id IPGroupId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Ip Group Name: %q", id.IpGroupName),
 	}
-	return fmt.Sprintf("I P Group (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("IP Group (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2023-11-01/loadbalancers/id_frontendipconfiguration.go
+++ b/resource-manager/network/2023-11-01/loadbalancers/id_frontendipconfiguration.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &FrontendIPConfigurationId{}
 
-// FrontendIPConfigurationId is a struct representing the Resource ID for a Frontend I P Configuration
+// FrontendIPConfigurationId is a struct representing the Resource ID for a Frontend IP Configuration
 type FrontendIPConfigurationId struct {
 	SubscriptionId              string
 	ResourceGroupName           string
@@ -90,7 +90,7 @@ func (id *FrontendIPConfigurationId) FromParseResult(input resourceids.ParseResu
 	return nil
 }
 
-// ValidateFrontendIPConfigurationID checks that 'input' can be parsed as a Frontend I P Configuration ID
+// ValidateFrontendIPConfigurationID checks that 'input' can be parsed as a Frontend IP Configuration ID
 func ValidateFrontendIPConfigurationID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -105,13 +105,13 @@ func ValidateFrontendIPConfigurationID(input interface{}, key string) (warnings 
 	return
 }
 
-// ID returns the formatted Frontend I P Configuration ID
+// ID returns the formatted Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.LoadBalancerName, id.FrontendIPConfigurationName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Frontend I P Configuration ID
+// Segments returns a slice of Resource ID Segments which comprise this Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -127,13 +127,13 @@ func (id FrontendIPConfigurationId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Frontend I P Configuration ID
+// String returns a human-readable description of this Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Load Balancer Name: %q", id.LoadBalancerName),
-		fmt.Sprintf("Frontend I P Configuration Name: %q", id.FrontendIPConfigurationName),
+		fmt.Sprintf("Frontend IP Configuration Name: %q", id.FrontendIPConfigurationName),
 	}
-	return fmt.Sprintf("Frontend I P Configuration (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Frontend IP Configuration (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2023-11-01/publicipprefixes/id_publicipprefix.go
+++ b/resource-manager/network/2023-11-01/publicipprefixes/id_publicipprefix.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &PublicIPPrefixId{}
 
-// PublicIPPrefixId is a struct representing the Resource ID for a Public I P Prefix
+// PublicIPPrefixId is a struct representing the Resource ID for a Public IP Prefix
 type PublicIPPrefixId struct {
 	SubscriptionId     string
 	ResourceGroupName  string
@@ -84,7 +84,7 @@ func (id *PublicIPPrefixId) FromParseResult(input resourceids.ParseResult) error
 	return nil
 }
 
-// ValidatePublicIPPrefixID checks that 'input' can be parsed as a Public I P Prefix ID
+// ValidatePublicIPPrefixID checks that 'input' can be parsed as a Public IP Prefix ID
 func ValidatePublicIPPrefixID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidatePublicIPPrefixID(input interface{}, key string) (warnings []string,
 	return
 }
 
-// ID returns the formatted Public I P Prefix ID
+// ID returns the formatted Public IP Prefix ID
 func (id PublicIPPrefixId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/publicIPPrefixes/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.PublicIPPrefixName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Public I P Prefix ID
+// Segments returns a slice of Resource ID Segments which comprise this Public IP Prefix ID
 func (id PublicIPPrefixId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id PublicIPPrefixId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Public I P Prefix ID
+// String returns a human-readable description of this Public IP Prefix ID
 func (id PublicIPPrefixId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
-		fmt.Sprintf("Public I P Prefix Name: %q", id.PublicIPPrefixName),
+		fmt.Sprintf("Public IP Prefix Name: %q", id.PublicIPPrefixName),
 	}
-	return fmt.Sprintf("Public I P Prefix (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Public IP Prefix (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-01-01/customipprefixes/id_customipprefix.go
+++ b/resource-manager/network/2024-01-01/customipprefixes/id_customipprefix.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &CustomIPPrefixId{}
 
-// CustomIPPrefixId is a struct representing the Resource ID for a Custom I P Prefix
+// CustomIPPrefixId is a struct representing the Resource ID for a Custom IP Prefix
 type CustomIPPrefixId struct {
 	SubscriptionId     string
 	ResourceGroupName  string
@@ -84,7 +84,7 @@ func (id *CustomIPPrefixId) FromParseResult(input resourceids.ParseResult) error
 	return nil
 }
 
-// ValidateCustomIPPrefixID checks that 'input' can be parsed as a Custom I P Prefix ID
+// ValidateCustomIPPrefixID checks that 'input' can be parsed as a Custom IP Prefix ID
 func ValidateCustomIPPrefixID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateCustomIPPrefixID(input interface{}, key string) (warnings []string,
 	return
 }
 
-// ID returns the formatted Custom I P Prefix ID
+// ID returns the formatted Custom IP Prefix ID
 func (id CustomIPPrefixId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/customIPPrefixes/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CustomIPPrefixName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Custom I P Prefix ID
+// Segments returns a slice of Resource ID Segments which comprise this Custom IP Prefix ID
 func (id CustomIPPrefixId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id CustomIPPrefixId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Custom I P Prefix ID
+// String returns a human-readable description of this Custom IP Prefix ID
 func (id CustomIPPrefixId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
-		fmt.Sprintf("Custom I P Prefix Name: %q", id.CustomIPPrefixName),
+		fmt.Sprintf("Custom IP Prefix Name: %q", id.CustomIPPrefixName),
 	}
-	return fmt.Sprintf("Custom I P Prefix (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Custom IP Prefix (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-01-01/ipallocations/id_ipallocation.go
+++ b/resource-manager/network/2024-01-01/ipallocations/id_ipallocation.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &IPAllocationId{}
 
-// IPAllocationId is a struct representing the Resource ID for a I P Allocation
+// IPAllocationId is a struct representing the Resource ID for a IP Allocation
 type IPAllocationId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -84,7 +84,7 @@ func (id *IPAllocationId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidateIPAllocationID checks that 'input' can be parsed as a I P Allocation ID
+// ValidateIPAllocationID checks that 'input' can be parsed as a IP Allocation ID
 func ValidateIPAllocationID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateIPAllocationID(input interface{}, key string) (warnings []string, e
 	return
 }
 
-// ID returns the formatted I P Allocation ID
+// ID returns the formatted IP Allocation ID
 func (id IPAllocationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/ipAllocations/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.IpAllocationName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this I P Allocation ID
+// Segments returns a slice of Resource ID Segments which comprise this IP Allocation ID
 func (id IPAllocationId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id IPAllocationId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this I P Allocation ID
+// String returns a human-readable description of this IP Allocation ID
 func (id IPAllocationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Ip Allocation Name: %q", id.IpAllocationName),
 	}
-	return fmt.Sprintf("I P Allocation (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("IP Allocation (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-01-01/ipgroups/id_ipgroup.go
+++ b/resource-manager/network/2024-01-01/ipgroups/id_ipgroup.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &IPGroupId{}
 
-// IPGroupId is a struct representing the Resource ID for a I P Group
+// IPGroupId is a struct representing the Resource ID for a IP Group
 type IPGroupId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -84,7 +84,7 @@ func (id *IPGroupId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidateIPGroupID checks that 'input' can be parsed as a I P Group ID
+// ValidateIPGroupID checks that 'input' can be parsed as a IP Group ID
 func ValidateIPGroupID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateIPGroupID(input interface{}, key string) (warnings []string, errors
 	return
 }
 
-// ID returns the formatted I P Group ID
+// ID returns the formatted IP Group ID
 func (id IPGroupId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/ipGroups/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.IpGroupName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this I P Group ID
+// Segments returns a slice of Resource ID Segments which comprise this IP Group ID
 func (id IPGroupId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id IPGroupId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this I P Group ID
+// String returns a human-readable description of this IP Group ID
 func (id IPGroupId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Ip Group Name: %q", id.IpGroupName),
 	}
-	return fmt.Sprintf("I P Group (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("IP Group (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-01-01/loadbalancers/id_frontendipconfiguration.go
+++ b/resource-manager/network/2024-01-01/loadbalancers/id_frontendipconfiguration.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &FrontendIPConfigurationId{}
 
-// FrontendIPConfigurationId is a struct representing the Resource ID for a Frontend I P Configuration
+// FrontendIPConfigurationId is a struct representing the Resource ID for a Frontend IP Configuration
 type FrontendIPConfigurationId struct {
 	SubscriptionId              string
 	ResourceGroupName           string
@@ -90,7 +90,7 @@ func (id *FrontendIPConfigurationId) FromParseResult(input resourceids.ParseResu
 	return nil
 }
 
-// ValidateFrontendIPConfigurationID checks that 'input' can be parsed as a Frontend I P Configuration ID
+// ValidateFrontendIPConfigurationID checks that 'input' can be parsed as a Frontend IP Configuration ID
 func ValidateFrontendIPConfigurationID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -105,13 +105,13 @@ func ValidateFrontendIPConfigurationID(input interface{}, key string) (warnings 
 	return
 }
 
-// ID returns the formatted Frontend I P Configuration ID
+// ID returns the formatted Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.LoadBalancerName, id.FrontendIPConfigurationName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Frontend I P Configuration ID
+// Segments returns a slice of Resource ID Segments which comprise this Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -127,13 +127,13 @@ func (id FrontendIPConfigurationId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Frontend I P Configuration ID
+// String returns a human-readable description of this Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Load Balancer Name: %q", id.LoadBalancerName),
-		fmt.Sprintf("Frontend I P Configuration Name: %q", id.FrontendIPConfigurationName),
+		fmt.Sprintf("Frontend IP Configuration Name: %q", id.FrontendIPConfigurationName),
 	}
-	return fmt.Sprintf("Frontend I P Configuration (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Frontend IP Configuration (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-01-01/publicipprefixes/id_publicipprefix.go
+++ b/resource-manager/network/2024-01-01/publicipprefixes/id_publicipprefix.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &PublicIPPrefixId{}
 
-// PublicIPPrefixId is a struct representing the Resource ID for a Public I P Prefix
+// PublicIPPrefixId is a struct representing the Resource ID for a Public IP Prefix
 type PublicIPPrefixId struct {
 	SubscriptionId     string
 	ResourceGroupName  string
@@ -84,7 +84,7 @@ func (id *PublicIPPrefixId) FromParseResult(input resourceids.ParseResult) error
 	return nil
 }
 
-// ValidatePublicIPPrefixID checks that 'input' can be parsed as a Public I P Prefix ID
+// ValidatePublicIPPrefixID checks that 'input' can be parsed as a Public IP Prefix ID
 func ValidatePublicIPPrefixID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidatePublicIPPrefixID(input interface{}, key string) (warnings []string,
 	return
 }
 
-// ID returns the formatted Public I P Prefix ID
+// ID returns the formatted Public IP Prefix ID
 func (id PublicIPPrefixId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/publicIPPrefixes/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.PublicIPPrefixName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Public I P Prefix ID
+// Segments returns a slice of Resource ID Segments which comprise this Public IP Prefix ID
 func (id PublicIPPrefixId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id PublicIPPrefixId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Public I P Prefix ID
+// String returns a human-readable description of this Public IP Prefix ID
 func (id PublicIPPrefixId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
-		fmt.Sprintf("Public I P Prefix Name: %q", id.PublicIPPrefixName),
+		fmt.Sprintf("Public IP Prefix Name: %q", id.PublicIPPrefixName),
 	}
-	return fmt.Sprintf("Public I P Prefix (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Public IP Prefix (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-05-01/customipprefixes/id_customipprefix.go
+++ b/resource-manager/network/2024-05-01/customipprefixes/id_customipprefix.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &CustomIPPrefixId{}
 
-// CustomIPPrefixId is a struct representing the Resource ID for a Custom I P Prefix
+// CustomIPPrefixId is a struct representing the Resource ID for a Custom IP Prefix
 type CustomIPPrefixId struct {
 	SubscriptionId     string
 	ResourceGroupName  string
@@ -84,7 +84,7 @@ func (id *CustomIPPrefixId) FromParseResult(input resourceids.ParseResult) error
 	return nil
 }
 
-// ValidateCustomIPPrefixID checks that 'input' can be parsed as a Custom I P Prefix ID
+// ValidateCustomIPPrefixID checks that 'input' can be parsed as a Custom IP Prefix ID
 func ValidateCustomIPPrefixID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateCustomIPPrefixID(input interface{}, key string) (warnings []string,
 	return
 }
 
-// ID returns the formatted Custom I P Prefix ID
+// ID returns the formatted Custom IP Prefix ID
 func (id CustomIPPrefixId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/customIPPrefixes/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CustomIPPrefixName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Custom I P Prefix ID
+// Segments returns a slice of Resource ID Segments which comprise this Custom IP Prefix ID
 func (id CustomIPPrefixId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id CustomIPPrefixId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Custom I P Prefix ID
+// String returns a human-readable description of this Custom IP Prefix ID
 func (id CustomIPPrefixId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
-		fmt.Sprintf("Custom I P Prefix Name: %q", id.CustomIPPrefixName),
+		fmt.Sprintf("Custom IP Prefix Name: %q", id.CustomIPPrefixName),
 	}
-	return fmt.Sprintf("Custom I P Prefix (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Custom IP Prefix (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-05-01/ipallocations/id_ipallocation.go
+++ b/resource-manager/network/2024-05-01/ipallocations/id_ipallocation.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &IPAllocationId{}
 
-// IPAllocationId is a struct representing the Resource ID for a I P Allocation
+// IPAllocationId is a struct representing the Resource ID for a IP Allocation
 type IPAllocationId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -84,7 +84,7 @@ func (id *IPAllocationId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidateIPAllocationID checks that 'input' can be parsed as a I P Allocation ID
+// ValidateIPAllocationID checks that 'input' can be parsed as a IP Allocation ID
 func ValidateIPAllocationID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateIPAllocationID(input interface{}, key string) (warnings []string, e
 	return
 }
 
-// ID returns the formatted I P Allocation ID
+// ID returns the formatted IP Allocation ID
 func (id IPAllocationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/ipAllocations/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.IpAllocationName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this I P Allocation ID
+// Segments returns a slice of Resource ID Segments which comprise this IP Allocation ID
 func (id IPAllocationId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id IPAllocationId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this I P Allocation ID
+// String returns a human-readable description of this IP Allocation ID
 func (id IPAllocationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Ip Allocation Name: %q", id.IpAllocationName),
 	}
-	return fmt.Sprintf("I P Allocation (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("IP Allocation (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-05-01/ipgroups/id_ipgroup.go
+++ b/resource-manager/network/2024-05-01/ipgroups/id_ipgroup.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &IPGroupId{}
 
-// IPGroupId is a struct representing the Resource ID for a I P Group
+// IPGroupId is a struct representing the Resource ID for a IP Group
 type IPGroupId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -84,7 +84,7 @@ func (id *IPGroupId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidateIPGroupID checks that 'input' can be parsed as a I P Group ID
+// ValidateIPGroupID checks that 'input' can be parsed as a IP Group ID
 func ValidateIPGroupID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateIPGroupID(input interface{}, key string) (warnings []string, errors
 	return
 }
 
-// ID returns the formatted I P Group ID
+// ID returns the formatted IP Group ID
 func (id IPGroupId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/ipGroups/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.IpGroupName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this I P Group ID
+// Segments returns a slice of Resource ID Segments which comprise this IP Group ID
 func (id IPGroupId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id IPGroupId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this I P Group ID
+// String returns a human-readable description of this IP Group ID
 func (id IPGroupId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Ip Group Name: %q", id.IpGroupName),
 	}
-	return fmt.Sprintf("I P Group (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("IP Group (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-05-01/loadbalancers/id_frontendipconfiguration.go
+++ b/resource-manager/network/2024-05-01/loadbalancers/id_frontendipconfiguration.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &FrontendIPConfigurationId{}
 
-// FrontendIPConfigurationId is a struct representing the Resource ID for a Frontend I P Configuration
+// FrontendIPConfigurationId is a struct representing the Resource ID for a Frontend IP Configuration
 type FrontendIPConfigurationId struct {
 	SubscriptionId              string
 	ResourceGroupName           string
@@ -90,7 +90,7 @@ func (id *FrontendIPConfigurationId) FromParseResult(input resourceids.ParseResu
 	return nil
 }
 
-// ValidateFrontendIPConfigurationID checks that 'input' can be parsed as a Frontend I P Configuration ID
+// ValidateFrontendIPConfigurationID checks that 'input' can be parsed as a Frontend IP Configuration ID
 func ValidateFrontendIPConfigurationID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -105,13 +105,13 @@ func ValidateFrontendIPConfigurationID(input interface{}, key string) (warnings 
 	return
 }
 
-// ID returns the formatted Frontend I P Configuration ID
+// ID returns the formatted Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.LoadBalancerName, id.FrontendIPConfigurationName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Frontend I P Configuration ID
+// Segments returns a slice of Resource ID Segments which comprise this Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -127,13 +127,13 @@ func (id FrontendIPConfigurationId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Frontend I P Configuration ID
+// String returns a human-readable description of this Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Load Balancer Name: %q", id.LoadBalancerName),
-		fmt.Sprintf("Frontend I P Configuration Name: %q", id.FrontendIPConfigurationName),
+		fmt.Sprintf("Frontend IP Configuration Name: %q", id.FrontendIPConfigurationName),
 	}
-	return fmt.Sprintf("Frontend I P Configuration (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Frontend IP Configuration (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-05-01/publicipprefixes/id_publicipprefix.go
+++ b/resource-manager/network/2024-05-01/publicipprefixes/id_publicipprefix.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &PublicIPPrefixId{}
 
-// PublicIPPrefixId is a struct representing the Resource ID for a Public I P Prefix
+// PublicIPPrefixId is a struct representing the Resource ID for a Public IP Prefix
 type PublicIPPrefixId struct {
 	SubscriptionId     string
 	ResourceGroupName  string
@@ -84,7 +84,7 @@ func (id *PublicIPPrefixId) FromParseResult(input resourceids.ParseResult) error
 	return nil
 }
 
-// ValidatePublicIPPrefixID checks that 'input' can be parsed as a Public I P Prefix ID
+// ValidatePublicIPPrefixID checks that 'input' can be parsed as a Public IP Prefix ID
 func ValidatePublicIPPrefixID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidatePublicIPPrefixID(input interface{}, key string) (warnings []string,
 	return
 }
 
-// ID returns the formatted Public I P Prefix ID
+// ID returns the formatted Public IP Prefix ID
 func (id PublicIPPrefixId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/publicIPPrefixes/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.PublicIPPrefixName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Public I P Prefix ID
+// Segments returns a slice of Resource ID Segments which comprise this Public IP Prefix ID
 func (id PublicIPPrefixId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id PublicIPPrefixId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Public I P Prefix ID
+// String returns a human-readable description of this Public IP Prefix ID
 func (id PublicIPPrefixId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
-		fmt.Sprintf("Public I P Prefix Name: %q", id.PublicIPPrefixName),
+		fmt.Sprintf("Public IP Prefix Name: %q", id.PublicIPPrefixName),
 	}
-	return fmt.Sprintf("Public I P Prefix (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Public IP Prefix (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-07-01/customipprefixes/id_customipprefix.go
+++ b/resource-manager/network/2024-07-01/customipprefixes/id_customipprefix.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &CustomIPPrefixId{}
 
-// CustomIPPrefixId is a struct representing the Resource ID for a Custom I P Prefix
+// CustomIPPrefixId is a struct representing the Resource ID for a Custom IP Prefix
 type CustomIPPrefixId struct {
 	SubscriptionId     string
 	ResourceGroupName  string
@@ -84,7 +84,7 @@ func (id *CustomIPPrefixId) FromParseResult(input resourceids.ParseResult) error
 	return nil
 }
 
-// ValidateCustomIPPrefixID checks that 'input' can be parsed as a Custom I P Prefix ID
+// ValidateCustomIPPrefixID checks that 'input' can be parsed as a Custom IP Prefix ID
 func ValidateCustomIPPrefixID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateCustomIPPrefixID(input interface{}, key string) (warnings []string,
 	return
 }
 
-// ID returns the formatted Custom I P Prefix ID
+// ID returns the formatted Custom IP Prefix ID
 func (id CustomIPPrefixId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/customIPPrefixes/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CustomIPPrefixName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Custom I P Prefix ID
+// Segments returns a slice of Resource ID Segments which comprise this Custom IP Prefix ID
 func (id CustomIPPrefixId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id CustomIPPrefixId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Custom I P Prefix ID
+// String returns a human-readable description of this Custom IP Prefix ID
 func (id CustomIPPrefixId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
-		fmt.Sprintf("Custom I P Prefix Name: %q", id.CustomIPPrefixName),
+		fmt.Sprintf("Custom IP Prefix Name: %q", id.CustomIPPrefixName),
 	}
-	return fmt.Sprintf("Custom I P Prefix (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Custom IP Prefix (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-07-01/ipallocations/id_ipallocation.go
+++ b/resource-manager/network/2024-07-01/ipallocations/id_ipallocation.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &IPAllocationId{}
 
-// IPAllocationId is a struct representing the Resource ID for a I P Allocation
+// IPAllocationId is a struct representing the Resource ID for a IP Allocation
 type IPAllocationId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -84,7 +84,7 @@ func (id *IPAllocationId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidateIPAllocationID checks that 'input' can be parsed as a I P Allocation ID
+// ValidateIPAllocationID checks that 'input' can be parsed as a IP Allocation ID
 func ValidateIPAllocationID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateIPAllocationID(input interface{}, key string) (warnings []string, e
 	return
 }
 
-// ID returns the formatted I P Allocation ID
+// ID returns the formatted IP Allocation ID
 func (id IPAllocationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/ipAllocations/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.IpAllocationName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this I P Allocation ID
+// Segments returns a slice of Resource ID Segments which comprise this IP Allocation ID
 func (id IPAllocationId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id IPAllocationId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this I P Allocation ID
+// String returns a human-readable description of this IP Allocation ID
 func (id IPAllocationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Ip Allocation Name: %q", id.IpAllocationName),
 	}
-	return fmt.Sprintf("I P Allocation (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("IP Allocation (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-07-01/ipgroups/id_ipgroup.go
+++ b/resource-manager/network/2024-07-01/ipgroups/id_ipgroup.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &IPGroupId{}
 
-// IPGroupId is a struct representing the Resource ID for a I P Group
+// IPGroupId is a struct representing the Resource ID for a IP Group
 type IPGroupId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -84,7 +84,7 @@ func (id *IPGroupId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidateIPGroupID checks that 'input' can be parsed as a I P Group ID
+// ValidateIPGroupID checks that 'input' can be parsed as a IP Group ID
 func ValidateIPGroupID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidateIPGroupID(input interface{}, key string) (warnings []string, errors
 	return
 }
 
-// ID returns the formatted I P Group ID
+// ID returns the formatted IP Group ID
 func (id IPGroupId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/ipGroups/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.IpGroupName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this I P Group ID
+// Segments returns a slice of Resource ID Segments which comprise this IP Group ID
 func (id IPGroupId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id IPGroupId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this I P Group ID
+// String returns a human-readable description of this IP Group ID
 func (id IPGroupId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Ip Group Name: %q", id.IpGroupName),
 	}
-	return fmt.Sprintf("I P Group (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("IP Group (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-07-01/loadbalancers/id_frontendipconfiguration.go
+++ b/resource-manager/network/2024-07-01/loadbalancers/id_frontendipconfiguration.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &FrontendIPConfigurationId{}
 
-// FrontendIPConfigurationId is a struct representing the Resource ID for a Frontend I P Configuration
+// FrontendIPConfigurationId is a struct representing the Resource ID for a Frontend IP Configuration
 type FrontendIPConfigurationId struct {
 	SubscriptionId              string
 	ResourceGroupName           string
@@ -90,7 +90,7 @@ func (id *FrontendIPConfigurationId) FromParseResult(input resourceids.ParseResu
 	return nil
 }
 
-// ValidateFrontendIPConfigurationID checks that 'input' can be parsed as a Frontend I P Configuration ID
+// ValidateFrontendIPConfigurationID checks that 'input' can be parsed as a Frontend IP Configuration ID
 func ValidateFrontendIPConfigurationID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -105,13 +105,13 @@ func ValidateFrontendIPConfigurationID(input interface{}, key string) (warnings 
 	return
 }
 
-// ID returns the formatted Frontend I P Configuration ID
+// ID returns the formatted Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/loadBalancers/%s/frontendIPConfigurations/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.LoadBalancerName, id.FrontendIPConfigurationName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Frontend I P Configuration ID
+// Segments returns a slice of Resource ID Segments which comprise this Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -127,13 +127,13 @@ func (id FrontendIPConfigurationId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Frontend I P Configuration ID
+// String returns a human-readable description of this Frontend IP Configuration ID
 func (id FrontendIPConfigurationId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Load Balancer Name: %q", id.LoadBalancerName),
-		fmt.Sprintf("Frontend I P Configuration Name: %q", id.FrontendIPConfigurationName),
+		fmt.Sprintf("Frontend IP Configuration Name: %q", id.FrontendIPConfigurationName),
 	}
-	return fmt.Sprintf("Frontend I P Configuration (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Frontend IP Configuration (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/network/2024-07-01/publicipprefixes/id_publicipprefix.go
+++ b/resource-manager/network/2024-07-01/publicipprefixes/id_publicipprefix.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &PublicIPPrefixId{}
 
-// PublicIPPrefixId is a struct representing the Resource ID for a Public I P Prefix
+// PublicIPPrefixId is a struct representing the Resource ID for a Public IP Prefix
 type PublicIPPrefixId struct {
 	SubscriptionId     string
 	ResourceGroupName  string
@@ -84,7 +84,7 @@ func (id *PublicIPPrefixId) FromParseResult(input resourceids.ParseResult) error
 	return nil
 }
 
-// ValidatePublicIPPrefixID checks that 'input' can be parsed as a Public I P Prefix ID
+// ValidatePublicIPPrefixID checks that 'input' can be parsed as a Public IP Prefix ID
 func ValidatePublicIPPrefixID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -99,13 +99,13 @@ func ValidatePublicIPPrefixID(input interface{}, key string) (warnings []string,
 	return
 }
 
-// ID returns the formatted Public I P Prefix ID
+// ID returns the formatted Public IP Prefix ID
 func (id PublicIPPrefixId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/publicIPPrefixes/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.PublicIPPrefixName)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Public I P Prefix ID
+// Segments returns a slice of Resource ID Segments which comprise this Public IP Prefix ID
 func (id PublicIPPrefixId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -119,12 +119,12 @@ func (id PublicIPPrefixId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Public I P Prefix ID
+// String returns a human-readable description of this Public IP Prefix ID
 func (id PublicIPPrefixId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
-		fmt.Sprintf("Public I P Prefix Name: %q", id.PublicIPPrefixName),
+		fmt.Sprintf("Public IP Prefix Name: %q", id.PublicIPPrefixName),
 	}
-	return fmt.Sprintf("Public I P Prefix (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Public IP Prefix (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/vmware/2022-05-01/workloadnetworks/id_publicip.go
+++ b/resource-manager/vmware/2022-05-01/workloadnetworks/id_publicip.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &PublicIPId{}
 
-// PublicIPId is a struct representing the Resource ID for a Public I P
+// PublicIPId is a struct representing the Resource ID for a Public IP
 type PublicIPId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -90,7 +90,7 @@ func (id *PublicIPId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidatePublicIPID checks that 'input' can be parsed as a Public I P ID
+// ValidatePublicIPID checks that 'input' can be parsed as a Public IP ID
 func ValidatePublicIPID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -105,13 +105,13 @@ func ValidatePublicIPID(input interface{}, key string) (warnings []string, error
 	return
 }
 
-// ID returns the formatted Public I P ID
+// ID returns the formatted Public IP ID
 func (id PublicIPId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.AVS/privateClouds/%s/workloadNetworks/default/publicIPs/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.PrivateCloudName, id.PublicIPId)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Public I P ID
+// Segments returns a slice of Resource ID Segments which comprise this Public IP ID
 func (id PublicIPId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -129,13 +129,13 @@ func (id PublicIPId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Public I P ID
+// String returns a human-readable description of this Public IP ID
 func (id PublicIPId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Private Cloud Name: %q", id.PrivateCloudName),
-		fmt.Sprintf("Public I P: %q", id.PublicIPId),
+		fmt.Sprintf("Public IP: %q", id.PublicIPId),
 	}
-	return fmt.Sprintf("Public I P (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Public IP (%s)", strings.Join(components, "\n"))
 }

--- a/resource-manager/vmware/2024-09-01/vmwares/id_publicip.go
+++ b/resource-manager/vmware/2024-09-01/vmwares/id_publicip.go
@@ -17,7 +17,7 @@ func init() {
 
 var _ resourceids.ResourceId = &PublicIPId{}
 
-// PublicIPId is a struct representing the Resource ID for a Public I P
+// PublicIPId is a struct representing the Resource ID for a Public IP
 type PublicIPId struct {
 	SubscriptionId    string
 	ResourceGroupName string
@@ -90,7 +90,7 @@ func (id *PublicIPId) FromParseResult(input resourceids.ParseResult) error {
 	return nil
 }
 
-// ValidatePublicIPID checks that 'input' can be parsed as a Public I P ID
+// ValidatePublicIPID checks that 'input' can be parsed as a Public IP ID
 func ValidatePublicIPID(input interface{}, key string) (warnings []string, errors []error) {
 	v, ok := input.(string)
 	if !ok {
@@ -105,13 +105,13 @@ func ValidatePublicIPID(input interface{}, key string) (warnings []string, error
 	return
 }
 
-// ID returns the formatted Public I P ID
+// ID returns the formatted Public IP ID
 func (id PublicIPId) ID() string {
 	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.AVS/privateClouds/%s/workloadNetworks/default/publicIPs/%s"
 	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.PrivateCloudName, id.PublicIPId)
 }
 
-// Segments returns a slice of Resource ID Segments which comprise this Public I P ID
+// Segments returns a slice of Resource ID Segments which comprise this Public IP ID
 func (id PublicIPId) Segments() []resourceids.Segment {
 	return []resourceids.Segment{
 		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
@@ -129,13 +129,13 @@ func (id PublicIPId) Segments() []resourceids.Segment {
 	}
 }
 
-// String returns a human-readable description of this Public I P ID
+// String returns a human-readable description of this Public IP ID
 func (id PublicIPId) String() string {
 	components := []string{
 		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
 		fmt.Sprintf("Private Cloud Name: %q", id.PrivateCloudName),
-		fmt.Sprintf("Public I P: %q", id.PublicIPId),
+		fmt.Sprintf("Public IP: %q", id.PublicIPId),
 	}
-	return fmt.Sprintf("Public I P (%s)", strings.Join(components, "\n"))
+	return fmt.Sprintf("Public IP (%s)", strings.Join(components, "\n"))
 }


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 
If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

While deploying an `azurerm_custom_ip_prefix` resource to my environment, I noticed a tiny typo in a failed apply: 

```
Error: retrieving Custom I P Prefix
```

I decided to track it down and saw that it was actually pretty prevalent. This PR updates all instances of "I P" to "IP".

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change
- [x] Typo Fixes

## Related Issue(s)
None


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
