### PR TITLE
Sanitize resourceManager endpoint to work around ARM metadata service inconsistencies

### DIFF
--- a/sdk/environments/from_endpoint_test.go
+++ b/sdk/environments/from_endpoint_test.go
@@ -17,6 +17,14 @@ func TestFromEndpoint_Public(t *testing.T) {
 	if actual.Name != "AzureCloud" {
 		t.Fatalf("expected the Environment name to be `AzureCloud` but got %q", actual.Name)
 	}
+
+	endpoint, ok := actual.ResourceManager.Endpoint()
+	if !ok {
+		t.Fatalf("refreshing MetaData from Endpoint: no `ResourceManager` endpoint was defined")
+	}
+	if *endpoint != "https://management.azure.com" {
+		t.Fatalf("expected the ResourceManager endpoint to be `https://management.azure.com` but got %q", *endpoint)
+	}
 }
 
 func TestFromEndpoint_USGovernment(t *testing.T) {
@@ -27,5 +35,13 @@ func TestFromEndpoint_USGovernment(t *testing.T) {
 
 	if actual.Name != "AzureUSGovernment" {
 		t.Fatalf("expected the Environment name to be `AzureUSGovernment` but got %q", actual.Name)
+	}
+
+	endpoint, ok := actual.ResourceManager.Endpoint()
+	if !ok {
+		t.Fatalf("refreshing MetaData from Endpoint: no `ResourceManager` endpoint was defined")
+	}
+	if *endpoint != "https://management.usgovcloudapi.net" {
+		t.Fatalf("expected the ResourceManager endpoint to be `https://management.usgovcloudapi.net` but got %q", *endpoint)
 	}
 }

--- a/sdk/internal/metadata/client.go
+++ b/sdk/internal/metadata/client.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -115,7 +116,9 @@ func (c *Client) GetMetaData(ctx context.Context) (*MetaData, error) {
 			OSSRDBMS:       normalizeResourceId(metadata.OssrDbmsResourceId),
 			Synapse:        normalizeResourceId(metadata.SynapseAnalyticsResourceId),
 		},
-		ResourceManagerEndpoint: metadata.ResourceManager,
+		// The resourceManager endpoint returned from the ARM metadata service is in an inconsistent format
+		// between clouds so sanitize it here to prevent downstream issues.
+		ResourceManagerEndpoint: strings.TrimRight(metadata.ResourceManager, "/"),
 	}, nil
 }
 

--- a/sdk/internal/metadata/client_test.go
+++ b/sdk/internal/metadata/client_test.go
@@ -74,7 +74,7 @@ func TestGetMetaData(t *testing.T) {
 			OSSRDBMS:       "https://ossrdbms-aad.database.windows.net",
 			Synapse:        "https://dev.azuresynapse.net",
 		},
-		ResourceManagerEndpoint: "https://management.azure.com/",
+		ResourceManagerEndpoint: "https://management.azure.com",
 	}
 
 	m, err := client.GetMetaData(ctx)


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 
If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

The ARM metadata service unfortunately returns the `resourceManager` endpoint in an inconsistent format between clouds. In Azure Public, it is returned with a trailing slash:

[https://management.azure.com/metadata/endpoints?api-version=2022-09-01](https://management.azure.com/metadata/endpoints?api-version=2022-09-01)

```json
  "resourceManager": "https://management.azure.com/",
```

However, in Azure US Government, it is returned without the trailing slash:

[https://management.usgovcloudapi.net/metadata/endpoints?api-version=2022-09-01](https://management.usgovcloudapi.net/metadata/endpoints?api-version=2022-09-01)

```json
  "resourceManager": "https://management.usgovcloudapi.net",
```

It seems that for the AzureRM Terraform Provider we require the environment to be initialized without the trailing slash. In fact, the built-in Azure Public environment (when not initializing the environment through the metadata endpoint) is also missing the trailing slash:

https://github.com/hashicorp/go-azure-sdk/blob/623b58827a96960e802c04f3746acd8f11e47222/sdk/environments/azure_public.go#L20

If the trailing slash is present, users have reported issues such as hashicorp/terraform-provider-azurerm#29819

Given how many dependencies other external clients might have on the ARM metadata service, it's likely easier to simply sanitize the input here rather than pressing for it to be changed on the ARM side.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes hashicorp/terraform-provider-azurerm#29819


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
