### PR TITLE
improve `resourceManagerResourcePathFromUri`

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -394,7 +394,7 @@ func (c *Client) NewRequest(ctx context.Context, input RequestOptions) (*Request
 		req.Header.Add("X-Ms-Correlation-Request-Id", c.CorrelationId)
 	}
 
-	path := strings.TrimPrefix(input.Path, "/")
+	path := strings.TrimLeft(input.Path, "/")
 	u, err := url.ParseRequestURI(fmt.Sprintf("%s/%s", c.BaseUri, path))
 	if err != nil {
 		return nil, err
@@ -706,7 +706,7 @@ func (c *Client) retryableClient(ctx context.Context, checkRetry retryablehttp.C
 	// This results into the following N(t) (by guaranteeing T(n) <= t):
 	// - n = floor(log(t+1)) - 1 		(0<=t<=63)
 	// - n = (t - 63)/61 + 6 			(t > 63)
-	var safeRetryNumber = func(t time.Duration) int {
+	safeRetryNumber := func(t time.Duration) int {
 		sec := t.Seconds()
 		if sec <= 63 {
 			return int(math.Floor(math.Log2(sec+1))) - 1

--- a/sdk/client/resourcemanager/poller_provisioning_state.go
+++ b/sdk/client/resourcemanager/poller_provisioning_state.go
@@ -177,7 +177,7 @@ func resourceManagerResourcePathFromUri(input string) (*string, error) {
 		return nil, fmt.Errorf("parsing %q: %+v", input, err)
 	}
 
-	segments := strings.Split(strings.TrimPrefix(parsed.Path, "/"), "/")
+	segments := strings.Split(strings.TrimLeft(parsed.Path, "/"), "/")
 	if len(segments) == 0 {
 		return nil, fmt.Errorf("polling uri was empty")
 	}


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

`resourceManagerResourcePathFromUri` assumes no prefixed forward slashes when it checks whether the number of segments are divisible by 2, to make this function more robust, strip ALL forward slashes rather than only the first (if multiple are present). Avoiding errors where it unintentionally drops the final segment (i.e. the resource name).

Additionally in `NewRequest`, ensure no prefixed forward slashes are present on the path, since we build the URL by including one between host and path regardless.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes #0000


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
