### PR TITLE
Resolve bug in ResourceManagerEndpoint

### DIFF
--- a/sdk/internal/metadata/client.go
+++ b/sdk/internal/metadata/client.go
@@ -115,7 +115,7 @@ func (c *Client) GetMetaData(ctx context.Context) (*MetaData, error) {
 			OSSRDBMS:       normalizeResourceId(metadata.OssrDbmsResourceId),
 			Synapse:        normalizeResourceId(metadata.SynapseAnalyticsResourceId),
 		},
-		ResourceManagerEndpoint: metadata.ResourceManager,
+		ResourceManagerEndpoint: normalizeEndpoint(metadata.ResourceManager),
 	}, nil
 }
 

--- a/sdk/internal/metadata/client_test.go
+++ b/sdk/internal/metadata/client_test.go
@@ -74,7 +74,7 @@ func TestGetMetaData(t *testing.T) {
 			OSSRDBMS:       "https://ossrdbms-aad.database.windows.net",
 			Synapse:        "https://dev.azuresynapse.net",
 		},
-		ResourceManagerEndpoint: "https://management.azure.com/",
+		ResourceManagerEndpoint: "https://management.azure.com",
 	}
 
 	m, err := client.GetMetaData(ctx)

--- a/sdk/internal/metadata/helpers.go
+++ b/sdk/internal/metadata/helpers.go
@@ -8,3 +8,8 @@ import "strings"
 func normalizeResourceId(resourceId string) string {
 	return strings.TrimRight(resourceId, "/")
 }
+
+func normalizeEndpoint(endpoint string) string {
+	return strings.TrimRight(endpoint, "/")
+}
+


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

When using an Azure Environment ( `go-azure-sdk/sdk/environments/environment.go` ), there is a difference in the value of `ResourceManager` endpoint when environment is loaded from metadata vs using build in values ( `go-azure-sdk/sdk/environments/azure_public.go` )

When using `azure_public.go`, `ResourceManager` = `"https://management.azure.com"`
When using `from_endpoint.go`, `ResourceManager` = `"https://management.azure.com/"`

Current test cases in `go-azure-sdk/sdk/internal/metadata/client_test.go` check for a `ResourceManagerEndpoint` that contains the trailing `/`, but this is inconsistent with the predefined environment files in all clouds.

This PR modifies `client.go` to ensure that `ResourceManagerEndpoint` doesn't contain a trailing `/` when loaded from metadata.  Ensuring consistency with existing patterns.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes https://github.com/hashicorp/packer-plugin-azure/issues/591
Fixes https://github.com/hashicorp/go-azure-sdk/issues/1302


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.
