### PR TITLE
`pollers` - keep polling until deadline when caller's context is canceled

### DIFF
--- a/sdk/client/pollers/poller.go
+++ b/sdk/client/pollers/poller.go
@@ -126,6 +126,18 @@ func (p *Poller) PollUntilDone(ctx context.Context) error {
 		return fmt.Errorf("internal-error: `ctx` should have a deadline")
 	}
 
+	// pollCtx drives the inner polling goroutine. It is decoupled from ctx so that
+	// when the caller cancels (e.g. SIGINT during `terraform apply`) we can keep
+	// polling and let the in-flight Azure operation complete - long enough for the
+	// resource ID to be persisted into state on the next layer up. pollCtx inherits
+	// the caller's deadline, so the resource's existing `timeouts.create` value
+	// naturally caps how long polling continues. The caller already declared that
+	// deadline as their patience ceiling; honoring it post-cancel is consistent
+	// with that declaration.
+	deadline, _ := ctx.Deadline()
+	pollCtx, cancelPoll := context.WithDeadline(context.WithoutCancel(ctx), deadline)
+	defer cancelPoll()
+
 	var wait sync.WaitGroup
 	wait.Add(1)
 
@@ -138,15 +150,21 @@ func (p *Poller) PollUntilDone(ctx context.Context) error {
 				retryDuration = p.latestResponse.PollInterval
 			}
 
-			if p.skipPollingDelay(ctx) {
+			if p.skipPollingDelay(pollCtx) {
 				retryDuration = 0
 			}
 
 			endTime := time.Now().Add(retryDuration)
 
-			<-time.After(time.Until(endTime))
+			select {
+			case <-time.After(time.Until(endTime)):
+			case <-pollCtx.Done():
+				p.latestError = pollCtx.Err()
+				wait.Done()
+				return
+			}
 
-			p.latestResponse, p.latestError = p.poller.Poll(ctx)
+			p.latestResponse, p.latestError = p.poller.Poll(pollCtx)
 
 			// first check the connection drop status
 			connectionHasBeenDropped := false
@@ -217,17 +235,38 @@ func (p *Poller) PollUntilDone(ctx context.Context) error {
 		waitDone <- struct{}{}
 	}()
 
+	// Wait for the polling goroutine to finish, then surface ctx.Err() to the caller.
+	// Used for both the deadline-expired path and the post-grace abort path.
+	abortWithCtxErr := func() error {
+		<-waitDone
+		if pointer.From(p.retryOnError) {
+			return p.latestError
+		}
+		p.latestResponse = nil
+		p.latestError = ctx.Err()
+		return p.latestError
+	}
+
 	select {
 	case <-waitDone:
 		break
 	case <-ctx.Done():
-		{
-			if pointer.From(p.retryOnError) {
-				return p.latestError
+		// On active cancellation (SIGINT, parent ctx cancel) keep polling until
+		// pollCtx hits its deadline - i.e. until the resource's timeouts.create
+		// elapses. The user already declared that deadline as their patience
+		// ceiling; letting the in-flight operation complete within it lets the
+		// caller (XThenPoll) reach SetID and persist state instead of orphaning
+		// the resource. The deadline-exceeded path skips the grace window because
+		// pollCtx will be Done at the same instant ctx is.
+		if errors.Is(ctx.Err(), context.Canceled) {
+			select {
+			case <-waitDone:
+				// poll completed within the remaining deadline - fall through and return its result
+			case <-pollCtx.Done():
+				return abortWithCtxErr()
 			}
-			p.latestResponse = nil
-			p.latestError = ctx.Err()
-			return p.latestError
+		} else {
+			return abortWithCtxErr()
 		}
 	}
 

--- a/sdk/client/pollers/poller_test.go
+++ b/sdk/client/pollers/poller_test.go
@@ -539,6 +539,234 @@ func TestPoller_InProgress_ShouldRaiseAnErrorWhenTimeoutExceeded(t *testing.T) {
 	}
 }
 
+func TestPoller_GraceOnCancel_PollCompletesBeforeDeadline(t *testing.T) {
+	// On caller cancellation (SIGINT) before the deadline elapses, polling continues
+	// until either the in-flight operation finishes or the deadline arrives. Here it
+	// finishes first - we expect a success return so callers like XThenPoll reach SetID.
+	expectedResponse := &client.Response{}
+	pollerType := fakePollerWithResults([]pollResult{
+		pollers.PollResult{
+			HttpResponse: &client.Response{},
+			PollInterval: 50 * time.Millisecond,
+			Status:       pollers.PollingStatusInProgress,
+		},
+		pollers.PollResult{
+			HttpResponse: expectedResponse,
+			PollInterval: 50 * time.Millisecond,
+			Status:       pollers.PollingStatusSucceeded,
+		},
+	})
+	poller := pollers.NewPoller(pollerType, 10*time.Millisecond, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+
+	parent, cancelDeadline := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
+	defer cancelDeadline()
+	ctx, cancel := context.WithCancel(parent)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	if err := poller.PollUntilDone(ctx); err != nil {
+		t.Fatalf("expected nil after deadline-bounded grace allowed completion, got: %+v", err)
+	}
+	if poller.LatestStatus() != pollers.PollingStatusSucceeded {
+		t.Fatalf("expected Succeeded, got %q", string(poller.LatestStatus()))
+	}
+	if poller.LatestResponse() != expectedResponse {
+		t.Fatalf("expected the recorded final response to match")
+	}
+}
+
+func TestPoller_GraceOnCancel_DeadlineCapsGrace(t *testing.T) {
+	// On cancellation when the operation does not finish before the deadline, the
+	// poller returns ctx.Err() once the deadline elapses. The deadline is the cap.
+	pollerType := fakePollerWithResults([]pollResult{
+		pollers.PollResult{
+			HttpResponse: &client.Response{},
+			PollInterval: 1 * time.Hour,
+			Status:       pollers.PollingStatusInProgress,
+		},
+	})
+	poller := pollers.NewPoller(pollerType, 10*time.Millisecond, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+
+	parent, cancelDeadline := context.WithDeadline(context.Background(), time.Now().Add(150*time.Millisecond))
+	defer cancelDeadline()
+	ctx, cancel := context.WithCancel(parent)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := poller.PollUntilDone(ctx)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("expected an error once the deadline cap was reached")
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Fatalf("expected to wait until close to the deadline, waited %v", elapsed)
+	}
+	if elapsed > 1*time.Second {
+		t.Fatalf("returned far later than the deadline: %v", elapsed)
+	}
+}
+
+func TestPoller_GraceOnCancel_DeadlineExceededReturnsImmediately(t *testing.T) {
+	// When the deadline expires (rather than the caller actively canceling), we get
+	// DeadlineExceeded - and there is no extra grace because pollCtx hits its own
+	// deadline at the same instant.
+	pollerType := fakePollerWithResults([]pollResult{
+		pollers.PollResult{
+			HttpResponse: &client.Response{},
+			PollInterval: 750 * time.Millisecond,
+			Status:       pollers.PollingStatusInProgress,
+		},
+	})
+	poller := pollers.NewPoller(pollerType, 10*time.Millisecond, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(200*time.Millisecond))
+	defer cancel()
+
+	start := time.Now()
+	err := poller.PollUntilDone(ctx)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("expected DeadlineExceeded error")
+	}
+	if elapsed > 1*time.Second {
+		t.Fatalf("expected near-deadline return, took %v", elapsed)
+	}
+}
+
+func TestPoller_GraceOnCancel_PollFailsDuringGrace(t *testing.T) {
+	// Caller cancels mid-poll, then before the deadline elapses the operation
+	// reports failure (e.g. ARM returns 5xx mapped to PollingFailedError). Grace
+	// should let the failure surface so the caller can act on it - not silently
+	// swallow it as ctx.Canceled.
+	expectedResponse := &client.Response{}
+	pollerType := fakePollerWithResults([]pollResult{
+		pollers.PollResult{
+			HttpResponse: &client.Response{},
+			PollInterval: 50 * time.Millisecond,
+			Status:       pollers.PollingStatusInProgress,
+		},
+		errorResult{
+			Error: pollers.PollingFailedError{
+				HttpResponse: expectedResponse,
+				Message:      "server gave up",
+			},
+		},
+	})
+	poller := pollers.NewPoller(pollerType, 10*time.Millisecond, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+
+	parent, cancelDeadline := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
+	defer cancelDeadline()
+	ctx, cancel := context.WithCancel(parent)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	err := poller.PollUntilDone(ctx)
+	if err == nil {
+		t.Fatalf("expected the underlying poll failure to surface, got nil")
+	}
+	expectedErrorMessage := "polling failed: server gave up"
+	if err.Error() != expectedErrorMessage {
+		t.Fatalf("expected %q, got %q", expectedErrorMessage, err.Error())
+	}
+	if poller.LatestStatus() != pollers.PollingStatusFailed {
+		t.Fatalf("expected Failed, got %q", string(poller.LatestStatus()))
+	}
+	if poller.LatestResponse() != expectedResponse {
+		t.Fatalf("expected the recorded final response to match")
+	}
+}
+
+func TestPoller_GraceOnCancel_DroppedConnectionsThenSucceeds(t *testing.T) {
+	// Caller cancels, the underlying transport drops a couple of connections
+	// during the grace window, the poll then recovers and the operation
+	// succeeds before the deadline. Grace must not break the existing
+	// dropped-connection retry behaviour.
+	expectedResponse := &client.Response{}
+	pollerType := fakePollerWithResults([]pollResult{
+		pollers.PollResult{
+			HttpResponse: &client.Response{},
+			PollInterval: 50 * time.Millisecond,
+			Status:       pollers.PollingStatusInProgress,
+		},
+		connectionDroppedResult{},
+		connectionDroppedResult{},
+		pollers.PollResult{
+			HttpResponse: expectedResponse,
+			PollInterval: 50 * time.Millisecond,
+			Status:       pollers.PollingStatusSucceeded,
+		},
+	})
+	poller := pollers.NewPoller(pollerType, 10*time.Millisecond, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+
+	parent, cancelDeadline := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
+	defer cancelDeadline()
+	ctx, cancel := context.WithCancel(parent)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	if err := poller.PollUntilDone(ctx); err != nil {
+		t.Fatalf("expected nil after grace + drop-recovery, got: %+v", err)
+	}
+	if poller.LatestStatus() != pollers.PollingStatusSucceeded {
+		t.Fatalf("expected Succeeded, got %q", string(poller.LatestStatus()))
+	}
+	if poller.LatestResponse() != expectedResponse {
+		t.Fatalf("expected the recorded final response to match")
+	}
+}
+
+func TestPoller_GraceOnCancel_RepeatedCancelIsIdempotent(t *testing.T) {
+	// Calling cancel() multiple times must not break the grace path. ctx.Done()
+	// fires once; subsequent cancels are no-ops at the channel level. This
+	// exercises the case where a caller defensively triggers cancel from
+	// multiple sites (e.g. an outer signal handler plus a timeout).
+	expectedResponse := &client.Response{}
+	pollerType := fakePollerWithResults([]pollResult{
+		pollers.PollResult{
+			HttpResponse: &client.Response{},
+			PollInterval: 50 * time.Millisecond,
+			Status:       pollers.PollingStatusInProgress,
+		},
+		pollers.PollResult{
+			HttpResponse: expectedResponse,
+			PollInterval: 50 * time.Millisecond,
+			Status:       pollers.PollingStatusSucceeded,
+		},
+	})
+	poller := pollers.NewPoller(pollerType, 10*time.Millisecond, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+
+	parent, cancelDeadline := context.WithDeadline(context.Background(), time.Now().Add(2*time.Second))
+	defer cancelDeadline()
+	ctx, cancel := context.WithCancel(parent)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+		cancel()
+		cancel()
+	}()
+
+	if err := poller.PollUntilDone(ctx); err != nil {
+		t.Fatalf("expected nil after grace + repeated cancel, got: %+v", err)
+	}
+	if poller.LatestStatus() != pollers.PollingStatusSucceeded {
+		t.Fatalf("expected Succeeded, got %q", string(poller.LatestStatus()))
+	}
+}
+
 type pollResult interface {
 }
 


### PR DESCRIPTION
## Community Note

* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review

## Description

When the caller's context is canceled (for example, SIGINT during `terraform apply`), `PollUntilDone` returns `context.Canceled` immediately. The Azure operation that was already accepted server-side continues to completion, leaving an orphaned resource that callers have to recover via manual `terraform import`.

This change runs the polling goroutine on a context decoupled from the caller's via `context.WithoutCancel`, preserving the caller's deadline. On `context.Canceled`, polling continues until either the operation completes or the deadline elapses. `context.DeadlineExceeded` returns immediately - the deadline is the caller's contract.

The deadline is therefore the natural upper bound on the grace window: zero new API surface, no configuration, and no behavior change when the caller is not actively canceling.

### Scope

This change addresses the **polling layer only**. Resources whose Create function does post-poll work using the same `ctx` (a Read-after-Create at the wrapper level, data-plane availability waits for storage accounts, kubelet identity probes for AKS, etc.) will still produce a `tainted` resource on cancel - because that follow-up work also fails with `context canceled` once the poll returns.

That is still a meaningful UX improvement over the baseline: the resource ID lands in state, recoverable with `terraform untaint` (or destroyed-and-recreated on the next `terraform apply`), instead of being orphaned and requiring manual `terraform import`. End-to-end validation against a real Azure subscription confirmed this:

| Scenario | Without this change | With this change |
|---|---|---|
| Create, SIGINT mid-poll | resource orphaned in Azure, missing from state | resource in state (tainted), exists in Azure |
| Create, SIGINT + SIGTERM | resource orphaned (escape hatch preserved) | resource orphaned (escape hatch preserved) |
| 10x parallelism=2, SIGINT after 2 in-flight | only the 2 in-flight orphan; the other 8 not started | the 2 in-flight land in state (tainted); the other 8 not started |

A follow-up at the provider layer is needed to remove the `tainted` marker; that is out of scope for the SDK.

### Test plan

- 6 new unit tests in `sdk/client/pollers/poller_test.go`:
  - `TestPoller_GraceOnCancel_PollCompletesBeforeDeadline`
  - `TestPoller_GraceOnCancel_DeadlineCapsGrace`
  - `TestPoller_GraceOnCancel_DeadlineExceededReturnsImmediately`
  - `TestPoller_GraceOnCancel_PollFailsDuringGrace`
  - `TestPoller_GraceOnCancel_DroppedConnectionsThenSucceeds`
  - `TestPoller_GraceOnCancel_RepeatedCancelIsIdempotent`
- `go test -race -count=10 ./client/pollers/...` passes locally.
- Whole `sdk` module green under `-race`.

This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancement
- [ ] Breaking Change

## Related Issue(s)

Refs hashicorp/terraform-provider-azurerm#32230 - azurerm-side request, with the end-to-end validation results above.
Refs hashicorp/terraform-provider-google#9874 - same problem on a sibling provider, open since 2021; the reporter explicitly asked for the design implemented here.
Refs hashicorp/terraform-provider-azurerm#28513 - closest prior provider-side attempt; closed pending an internal design decision.

Out of scope: poll-time API failures (e.g. hashicorp/terraform-provider-azurerm#28511 image-pull failure on `azurerm_container_app`). That is a separate SetID-timing question, not addressed here.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the SDK.

## Changes to Security Controls

No changes to security controls. The grace window is bounded by the caller's existing deadline, which is already an accepted contract; no new surface is exposed for prolonged operations.

> [!NOTE]
> If this PR changes meaningfully during the course of review please update the title and description as required.