### PR TITLE
`sdk`: add customize initial poll delay via ctx

### DIFF
--- a/sdk/client/pollers/context.go
+++ b/sdk/client/pollers/context.go
@@ -3,12 +3,16 @@
 
 package pollers
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 type pollKey int
 
 const (
 	skipPollingDelayKey pollKey = iota
+	initialPollingDelayKey
 )
 
 // WithSkipPollingDelay returns a new context with the skip polling delay flag set.
@@ -23,4 +27,22 @@ func ShouldSkipPollingDelay(ctx context.Context) bool {
 		return v
 	}
 	return false
+}
+
+// WithInitialPollingDelay returns a new context with the initial polling delay value set.
+// This is used to signal to PollUntilDone the initial delay before the first polling attempt.
+// It's intended to ignore if value is less than or equal to 0
+func WithInitialPollingDelay(ctx context.Context, value time.Duration) context.Context {
+	if value <= 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, initialPollingDelayKey, value)
+}
+
+// GetInitialPollingDelay returns the initial polling delay value if set.
+func GetInitialPollingDelay(ctx context.Context) time.Duration {
+	if v, ok := ctx.Value(initialPollingDelayKey).(time.Duration); ok {
+		return v
+	}
+	return 0
 }

--- a/sdk/client/pollers/poller.go
+++ b/sdk/client/pollers/poller.go
@@ -132,6 +132,10 @@ func (p *Poller) PollUntilDone(ctx context.Context) error {
 	go func() {
 		connectionDropCounter := 0
 		retryDuration := p.initialDelayDuration
+		if ctxInitialDelay := GetInitialPollingDelay(ctx); ctxInitialDelay > 0 {
+			retryDuration = ctxInitialDelay
+		}
+
 		for {
 			// determine the next retry duration / how long to poll for
 			if p.latestResponse != nil {

--- a/sdk/client/resourcemanager/poller.go
+++ b/sdk/client/resourcemanager/poller.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
@@ -55,7 +57,11 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 	// finally, if it was a Delete that returned a 200/204
 	statusCodesToCheckDelete := response.StatusCode == http.StatusOK || response.StatusCode == http.StatusCreated || response.StatusCode == http.StatusAccepted || response.StatusCode == http.StatusNoContent
 	if methodIsDelete && statusCodesToCheckDelete {
-		deletePoller, deletePollerErr := deletePollerFromResponse(response, client, DefaultPollingInterval)
+		interval := DefaultPollingInterval
+		if retryAfter := retryAfterFromResponse(response); retryAfter != nil {
+			interval = *retryAfter
+		}
+		deletePoller, deletePollerErr := deletePollerFromResponse(response, client, interval)
 		if deletePollerErr != nil {
 			return pollers.Poller{}, fmt.Errorf("building delete poller: %+v", deletePollerErr)
 		}
@@ -80,4 +86,14 @@ func isLROSelfReference(lroPollingUri, originalRequestUri string) bool {
 	// The Query String can be a different API version / options and in some cases the Host
 	// is returned with `:443` - so the path should be sufficient as a check.
 	return strings.EqualFold(first.Path, second.Path)
+}
+
+func retryAfterFromResponse(response *client.Response) *time.Duration {
+	if s, ok := response.Header["Retry-After"]; ok {
+		if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
+			duration := time.Second * time.Duration(sleep)
+			return &duration
+		}
+	}
+	return nil
 }

--- a/sdk/client/resourcemanager/poller_lro.go
+++ b/sdk/client/resourcemanager/poller_lro.go
@@ -66,10 +66,8 @@ func longRunningOperationPollerFromResponse(resp *client.Response, client *clien
 		poller.originalUrl = resp.Request.URL
 	}
 
-	if s, ok := resp.Header["Retry-After"]; ok {
-		if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
-			poller.initialRetryDuration = time.Second * time.Duration(sleep)
-		}
+	if retryAfter := retryAfterFromResponse(resp); retryAfter != nil {
+		poller.initialRetryDuration = *retryAfter
 	}
 
 	return &poller, nil


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 
If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->

### InitialPollingDelay in `ctx`
The `DefaultPollingInterval` is 10 seconds and there is no way to customize it when the LRO response header doesn't contain the `Retry-After` header. this may cause long waiting time for resources like `azurerm_netowork_interface`: it has a/many lock[s] and may create many instances at one apply, but the LRO has no retry-after header and 10 seconds initial delay is too long, so this PR add a `WithInitialPollingDelay` method to customize the delay value.

related issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/30365 the create of network interface LRO actually finished within 1 second, but because of the 10 second default initial delay and the locks cause sequential creation, the customer has to wait for a long time to complete. there was also an internal IcM ticket in MS about creating 100+ NIC in one apply.

### delete poller honor the Retry-After header
The current delete poller always using `deletePoller` with `DefaultPollingInterval` but actually the DELETE response may contain the Retry-After header, this PR also add the logic to honor it, for example the delete of `azurerm_network_interface`s `Retry-After` value is 4.

```
DELETE https://management.azure.com/subscriptions/<>/resourceGroups/acctestRG-xuwu1/providers/Microsoft.Network/networkInterfaces/acctestni2-subnet2?api-version=2025-01-01 HTTP/2.0
user-agent: HashiCorp/go-azure-sdk (Go-http-Client/1.1 networkinterfaces/2025-01-01) HashiCorp Terraform/1.14.3
authorization: Bearer -<>
content-type: application/json; charset=utf-8
accept-encoding: gzip

HTTP/2.0 200 
cache-control: no-cache
pragma: no-cache
expires: -1
location: https://management.azure.com/subscriptions/<>/providers/Microsoft.Network/locations/eastus2/operationResults/<>?api-version=2025-01-01&t=<>
retry-after: 4
date: Fri, 01 May 2026 01:16:09 GMT
content-length: 0
```
 
<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes #0000


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
