### PR TITLE
`auth`: trim trailing slash from LoginEndpoint in tokenEndpoint

### DIFF
--- a/sdk/auth/client_credentials.go
+++ b/sdk/auth/client_credentials.go
@@ -378,5 +378,5 @@ func tokenEndpoint(endpoint environments.Authorization, tenant string) string {
 	if tenant == "" {
 		tenant = "common"
 	}
-	return fmt.Sprintf("%s/%s/oauth2/v2.0/token", endpoint.LoginEndpoint, tenant)
+	return fmt.Sprintf("%s/%s/oauth2/v2.0/token", strings.TrimRight(endpoint.LoginEndpoint, "/"), tenant)
 }

--- a/sdk/auth/token_endpoint_test.go
+++ b/sdk/auth/token_endpoint_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package auth_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+	"github.com/hashicorp/go-azure-sdk/sdk/internal/test"
+)
+
+func TestClientCertificateAuthorizer_TrailingSlashLoginEndpoint(t *testing.T) {
+	ctx := context.Background()
+	env := environments.AzurePublic()
+
+	// Simulate a custom cloud that returns a login endpoint with a trailing slash
+	authorization := *env.Authorization
+	authorization.LoginEndpoint = strings.TrimRight(authorization.LoginEndpoint, "/") + "/"
+	env.Authorization = &authorization
+
+	auth.Client = &test.AzureADAccessTokenMockClient{
+		Authorization: authorization,
+	}
+
+	opts := auth.ClientCertificateAuthorizerOptions{
+		Environment:  *env,
+		Api:          env.MicrosoftGraph,
+		TenantId:     "00000000-1111-0000-0000-000000000000",
+		AuxTenantIds: test.AuxiliaryTenantIds,
+		ClientId:     "11111111-0000-0000-0000-000000000000",
+		Pkcs12Data:   test.Base64DecodeCertificate(t, dummyClientCertificate),
+		Pkcs12Pass:   "certpassword",
+	}
+
+	authorizer, err := auth.NewClientCertificateAuthorizer(ctx, opts)
+	if err != nil {
+		t.Fatalf("NewClientCertificateAuthorizer(): %v", err)
+	}
+
+	if authorizer == nil {
+		t.Fatal("authorizer is nil, expected Authorizer")
+	}
+
+	if _, err = testObtainAccessToken(ctx, authorizer); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClientSecretAuthorizer_TrailingSlashLoginEndpoint(t *testing.T) {
+	ctx := context.Background()
+	env := environments.AzurePublic()
+
+	// Simulate a custom cloud that returns a login endpoint with a trailing slash
+	authorization := *env.Authorization
+	authorization.LoginEndpoint = strings.TrimRight(authorization.LoginEndpoint, "/") + "/"
+	env.Authorization = &authorization
+
+	auth.Client = &test.AzureADAccessTokenMockClient{
+		Authorization: authorization,
+	}
+
+	opts := auth.ClientSecretAuthorizerOptions{
+		Environment:  *env,
+		Api:          env.MicrosoftGraph,
+		TenantId:     "00000000-1111-0000-0000-000000000000",
+		AuxTenantIds: test.AuxiliaryTenantIds,
+		ClientId:     "11111111-0000-0000-0000-000000000000",
+		ClientSecret: "supersecret",
+	}
+
+	authorizer, err := auth.NewClientSecretAuthorizer(ctx, opts)
+	if err != nil {
+		t.Fatalf("NewClientSecretAuthorizer(): %v", err)
+	}
+
+	if authorizer == nil {
+		t.Fatal("authorizer is nil, expected Authorizer")
+	}
+
+	if _, err = testObtainAccessToken(ctx, authorizer); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

When custom cloud (AGC) metadata discovery returns a login endpoint with a trailing slash (e.g., `https://login.microsoftonline.<suffix>/`), the `tokenEndpoint` function in `sdk/auth/client_credentials.go` constructs a token URL with a double slash before the tenant ID:

```
https://login.microsoftonline.<suffix>//<tenant-id>/oauth2/v2.0/token
```

This causes client certificate authentication to fail because the signed JWT assertion uses the malformed URL as the `aud` claim, which does not match the canonical realm issuer. The token service rejects the request with:

```
AADSTS700023: Client assertion audience claim does not match Realm issuer
```

Client secret authentication is unaffected because it does not use the token URL as an audience claim.

### Fix

Apply `strings.TrimRight` to normalize `endpoint.LoginEndpoint` before constructing the token URL:

```go
return fmt.Sprintf("%s/%s/oauth2/v2.0/token", strings.TrimRight(endpoint.LoginEndpoint, "/"), tenant)
```

This is a single-line change. The `strings` package was already imported in the file.

### Tests

Added two integration tests in `sdk/auth/token_endpoint_test.go` that exercise the full authorizer flow with a trailing-slash login endpoint:

- `TestClientCertificateAuthorizer_TrailingSlashLoginEndpoint`
- `TestClientSecretAuthorizer_TrailingSlashLoginEndpoint`

Both tests use the existing `AzureADAccessTokenMockClient`, whose path regex inherently validates that the constructed URL does not contain a double slash.

This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement
- [ ] Breaking Change

## Related Issue(s)
Fixes #1329


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No changes to security controls. This change normalizes URL path construction only.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
