### PR TITLE
add 409 retry logic for resource manager calls

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -763,6 +763,11 @@ func (c *Client) retryableClient(ctx context.Context, checkRetry retryablehttp.C
 			if s, ok := resp.Header["Retry-After"]; ok {
 				if sleep, err := strconv.ParseInt(s[0], 10, 64); err == nil {
 					return time.Second * time.Duration(sleep)
+				} else if parsedTime, err := http.ParseTime(s[0]); err == nil {
+					sleepDuration := time.Until(parsedTime)
+					if sleepDuration > 0 {
+						return sleepDuration
+					}
 				}
 			}
 		}

--- a/sdk/client/client_test.go
+++ b/sdk/client/client_test.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/sdk/internal/test"
@@ -771,4 +772,53 @@ func (rt *recorderRecorder) RoundTrip(req *http.Request) (*http.Response, error)
 		return rt.roundTripFunc(req)
 	}
 	return nil, fmt.Errorf("roundTripFunc missing from mock")
+}
+
+func TestClient_RetryAfterBackoff(t *testing.T) {
+	ctx := context.TODO()
+	c := NewClient("http://localhost", "testService", "v1.0")
+
+	// Get the retryable client
+	r := c.retryableClient(ctx, nil)
+
+	t.Run("DelaySeconds", func(t *testing.T) {
+		resp := &http.Response{
+			Header: make(http.Header),
+		}
+		resp.Header.Set("Retry-After", "120")
+
+		sleep := r.Backoff(time.Second, 5*time.Minute, 0, resp)
+		if sleep != 120*time.Second {
+			t.Errorf("expected 120s, got %v", sleep)
+		}
+	})
+
+	t.Run("HTTPDate", func(t *testing.T) {
+		resp := &http.Response{
+			Header: make(http.Header),
+		}
+		// Set date to 2 minutes from now
+		future := time.Now().Add(2 * time.Minute).UTC()
+		resp.Header.Set("Retry-After", future.Format(http.TimeFormat))
+
+		sleep := r.Backoff(time.Second, 5*time.Minute, 0, resp)
+		
+		// The sleep duration should be close to 2 minutes. We can check if it's within a reasonable bounds.
+		if sleep < 118*time.Second || sleep > 122*time.Second {
+			t.Errorf("expected ~120s, got %v", sleep)
+		}
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		resp := &http.Response{
+			Header: make(http.Header),
+		}
+		resp.Header.Set("Retry-After", "invalid")
+
+		sleep := r.Backoff(time.Second, time.Minute, 0, resp)
+		// Should fall back to default exponential backoff (attempt 0 -> 1s)
+		if sleep != time.Second {
+			t.Errorf("expected 1s, got %v", sleep)
+		}
+	})
 }

--- a/sdk/client/resourcemanager/retry_policies.go
+++ b/sdk/client/resourcemanager/retry_policies.go
@@ -4,7 +4,10 @@
 package resourcemanager
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -19,6 +22,7 @@ import (
 var defaultRetryFunctions = []client.RequestRetryFunc{
 	// NOTE: 429 is handled by the base library
 	handleResourceProviderNotRegistered,
+	RetryOn409ConflictFunc,
 }
 
 func handleResourceProviderNotRegistered(r *http.Response, o *odata.OData) (bool, error) {
@@ -52,4 +56,53 @@ Resource Providers can take a while to register, you can check the status by run
 
 Once this outputs "Registered" the Resource Provider is available for use and you can re-run Terraform.
 `, strings.Join(messageSplit, "\n"))
+}
+
+// RetryOn409ConflictFunc is a RequestRetryFunc that inspects HTTP 409 Conflict responses.
+// It will always retry if a Retry-After header is provided by the server.
+// If the Retry-After header is omitted, the response payload is evaluated to determine if the resource is in a
+// non-terminal provisioning state (such as Updating, Creating, Deleting, or InProgress).
+// If it is in a non-terminal state, it returns true, indicating a retry should be performed using the default backoff.
+// Known terminal states (Failed, Canceled, Cancelled, Succeeded) will not be retried unless a Retry-After header is present.
+func RetryOn409ConflictFunc(resp *http.Response, o *odata.OData) (bool, error) {
+	if resp == nil || resp.StatusCode != http.StatusConflict {
+		return false, nil
+	}
+
+	if _, ok := resp.Header["Retry-After"]; ok {
+		return true, nil
+	}
+
+	if resp.Body != nil {
+		respBody, err := io.ReadAll(resp.Body)
+		if err == nil {
+			// Reassign the body so it can be consumed later
+			resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
+
+			var state struct {
+				Status     string `json:"status"`
+				Properties struct {
+					ProvisioningState string `json:"provisioningState"`
+				} `json:"properties"`
+			}
+
+			if err := json.Unmarshal(respBody, &state); err == nil {
+				s := state.Status
+				if state.Properties.ProvisioningState != "" {
+					s = state.Properties.ProvisioningState
+				}
+
+				if s != "" {
+					// Check for known terminal states
+					if strings.EqualFold(s, "Failed") || strings.EqualFold(s, "Canceled") || strings.EqualFold(s, "Cancelled") || strings.EqualFold(s, "Succeeded") {
+						return false, nil
+					}
+					// If it's a non-terminal state, retry
+					return true, nil
+				}
+			}
+		}
+	}
+
+	return false, nil
 }

--- a/sdk/client/resourcemanager/retry_policies_test.go
+++ b/sdk/client/resourcemanager/retry_policies_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcemanager
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestRetryOn409ConflictFunc(t *testing.T) {
+	cases := []struct {
+		name          string
+		statusCode    int
+		headers       http.Header
+		body          string
+		expectedRetry bool
+	}{
+		{
+			name:          "Not a 409",
+			statusCode:    http.StatusOK,
+			expectedRetry: false,
+		},
+		{
+			name:          "409 with Retry-After header",
+			statusCode:    http.StatusConflict,
+			headers:       http.Header{"Retry-After": []string{"120"}},
+			expectedRetry: true,
+		},
+		{
+			name:          "409 with non-terminal status",
+			statusCode:    http.StatusConflict,
+			body:          `{"status": "Updating"}`,
+			expectedRetry: true,
+		},
+		{
+			name:          "409 with non-terminal provisioningState",
+			statusCode:    http.StatusConflict,
+			body:          `{"properties": {"provisioningState": "Creating"}}`,
+			expectedRetry: true,
+		},
+		{
+			name:          "409 with terminal status Failed",
+			statusCode:    http.StatusConflict,
+			body:          `{"status": "Failed"}`,
+			expectedRetry: false,
+		},
+		{
+			name:          "409 with terminal status Succeeded",
+			statusCode:    http.StatusConflict,
+			body:          `{"properties": {"provisioningState": "Succeeded"}}`,
+			expectedRetry: false,
+		},
+		{
+			name:          "409 with empty body",
+			statusCode:    http.StatusConflict,
+			body:          ``,
+			expectedRetry: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: tc.statusCode,
+				Header:     tc.headers,
+			}
+			if tc.body != "" {
+				resp.Body = io.NopCloser(bytes.NewBufferString(tc.body))
+			}
+
+			retry, err := RetryOn409ConflictFunc(resp, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if retry != tc.expectedRetry {
+				t.Errorf("expected retry=%v, got %v", tc.expectedRetry, retry)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Experimental change to test behavioural effects of dealing with unreliable endpoints and behaviours.

