### PR TITLE
`gha` - reduce release action bottleneck

### DIFF
--- a/.github/workflows/automation-release.yaml
+++ b/.github/workflows/automation-release.yaml
@@ -10,7 +10,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    if: ${{ (github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'release-once-merged')) || github.event_name == 'workflow_dispatch' }}
+    runs-on: custom-linux-xl
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [sdk, resource-manager, microsoft-graph, data-plane]
+    steps:
+      - name: Mount RAM Disks
+        run: |
+          sudo mount -t tmpfs -o size=16G tmpfs ${{ github.workspace }}
+          sudo chown -R $USER:$USER ${{ github.workspace }}
+          mkdir -p ~/.cache/go-build ~/go/pkg/mod
+          sudo mount -t tmpfs -o size=8G tmpfs ~/.cache/go-build
+          sudo mount -t tmpfs -o size=8G tmpfs ~/go/pkg/mod
+          sudo chown -R $USER:$USER ~/.cache/go-build ~/go/pkg/mod
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: ./.go-version
+
+      - name: run the unit tests
+        run: make test-ci-${{ matrix.component }}
+
   release-go-sdk:
+    needs: [test]
     if: ${{ (github.event.pull_request.merged == true && contains( github.event.pull_request.labels.*.name, 'release-once-merged')) || github.event_name == 'workflow_dispatch' }}
     runs-on: custom-linux-medium
     permissions:
@@ -26,11 +53,6 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ./.go-version
-
-      - name: run the unit tests
-        run: |
-          make tools
-          make test
 
       - id: version-number
         name: "Determining the Version Number.."

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -43,8 +43,10 @@ test-ci-microsoft-graph:
 test-ci-data-plane:
 	cd ./data-plane/ && go test -v ./...
 
+test-ci: test-ci-sdk test-ci-resource-manager test-ci-microsoft-graph test-ci-data-plane
+
 tools:
 	@echo "==> installing required tooling..."
 	go install golang.org/x/tools/cmd/goimports@latest
 
-.PHONY: fmt imports prepare test test-ci-sdk test-ci-resource-manager test-ci-microsoft-graph test-ci-data-plane tools
+.PHONY: fmt imports prepare test test-ci test-ci-sdk test-ci-resource-manager test-ci-microsoft-graph test-ci-data-plane tools


### PR DESCRIPTION
Note: We could arguably remove the testing step entirely as the `pr-unit-tests.yaml` covers this before we merge anything anyway? I've left it in as this should already save us around 80% on time waiting.

also added a collected `test-ci` make target for developer convenience.