### PR TITLE
pollers - allow `PollerFromResponse` to return poller based on async-operation URL for Delete requests

### DIFF
--- a/sdk/client/resourcemanager/poller.go
+++ b/sdk/client/resourcemanager/poller.go
@@ -25,7 +25,7 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 	methodIsDelete := strings.EqualFold(response.Request.Method, "DELETE")
 	lroPollingUri := pollingUriForLongRunningOperation(response)
 	lroIsSelfReference := isLROSelfReference(lroPollingUri, originalRequestUri)
-	if isLroStatus && lroPollingUri != "" && !methodIsDelete && !lroIsSelfReference {
+	if isLroStatus && lroPollingUri != "" && !lroIsSelfReference {
 		lro, lroErr := longRunningOperationPollerFromResponse(response, client.Client)
 		if lroErr != nil {
 			return pollers.Poller{}, fmt.Errorf("building long-running-operation poller: %+v", lroErr)
@@ -52,7 +52,7 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 		return pollers.NewPoller(provisioningState, provisioningState.initialRetryDuration, pollers.DefaultNumberOfDroppedConnectionsToAllow), nil
 	}
 
-	// finally, if it was a Delete that returned a 200/204
+	// finally, if it was a Delete that did not return a Polling URI header, and returned 200, 201, 202, or 204
 	statusCodesToCheckDelete := response.StatusCode == http.StatusOK || response.StatusCode == http.StatusCreated || response.StatusCode == http.StatusAccepted || response.StatusCode == http.StatusNoContent
 	if methodIsDelete && statusCodesToCheckDelete {
 		deletePoller, deletePollerErr := deletePollerFromResponse(response, client, DefaultPollingInterval)


### PR DESCRIPTION


<!--  All Submissions -->

## Community Note
<!-- Please leave the community note as is. -->
* Please vote on this PR by adding a :thumbsup: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original PR to help the community and maintainers prioritize for review
* Please do not leave comments along the lines of "+1", "me too" or "any updates", they generate extra noise for PR followers and do not help prioritize for review


## Description

Removes a single condition to allow `Delete` operations to poll on the returned async operation URL rather than just polling for a 404 on the resource URL.

Reasoning behind this change:

Certain resources in Azure may accept an initial `Delete` request, but fail later on due to some condition. Because the current logic just checks for a 404, the operation keeps polling until the context expires. At which point it surfaces only a `context deadline exceeded` error to the user rather than an actionable error message.

`azurerm_postgresql_flexible_server_active_directory_administrator` is an example of this, if you attempt a delete while certain objects still depend on it (e.g. setting this admin object as the owner of a table in a database), Azure accepts the initial delete request with a `202` response but performing a `GET` on the returned async operation url (from `azure-asyncoperation` header) returns the following error:

```
Status: "AadAuthPrincipalDropFailed"
│ Code: ""
│ Message: "Failed to drop Microsoft Entra principal. Reason: '2BP01: role \"acctest-fs-0831-grp\" cannot be dropped because some objects depend on it\n\nDETAIL: Detail redacted as it may contain sensitive data. Specify 'Include Error Detail' in the connection string to include this information.'."
```

which is never surfaced to the user, and the resource proceeds to poll until the 30 min timeout expires.


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancement
- [ ] Breaking Change




<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

> [!NOTE] 
> If this PR changes meaningfully during the course of review please update the title and description as required.
